### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-02-19
+
+### Changed
+- Switched to npm OIDC trusted publishing (no static tokens)
+- Added provenance attestation for supply chain security
+- Release workflow validates tag matches package.json version
+
+### Security
+- CI: Gitleaks secret detection, CodeQL analysis, Semgrep SAST
+- Dependabot: Weekly dependency and GitHub Actions updates
+- Branch protection with required status checks
+
 ## [0.1.0] - 2026-02-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-scf",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 0.1.1
- Add changelog entry for OIDC trusted publishing, provenance, and security CI

## After merge
Tag and push to trigger the release workflow:
```bash
git tag v0.1.1 && git push origin v0.1.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)