### PR TITLE
fix: clear NODE_AUTH_TOKEN for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ''  # Clear setup-node's default token so npm uses OIDC
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Clear `NODE_AUTH_TOKEN` in the publish step so npm uses OIDC token exchange
- `actions/setup-node` with `registry-url` sets a default token that conflicts with OIDC

## Root Cause
`actions/setup-node` creates `.npmrc` with `NODE_AUTH_TOKEN` placeholder. npm sees this token and tries to use it instead of the OIDC flow, resulting in "Access token expired" + E404.

## Test plan
- [ ] CI passes
- [ ] After merge, bump to v0.1.3, tag, and verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)