### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-02-19
+
+### Fixed
+- Fixed OIDC token conflict with setup-node's default NODE_AUTH_TOKEN
+
 ## [0.1.2] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-scf",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump + changelog for OIDC fix. After merge, tag v0.1.3 to publish.