### PR TITLE
fix: remove registry-url to enable OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure npm for OIDC publishing
+        run: npm config set registry https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm ci
@@ -60,8 +62,6 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ''  # Clear setup-node's default token so npm uses OIDC
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `actions/setup-node` (it creates `.npmrc` with `NODE_AUTH_TOKEN` that overrides OIDC)
- Remove explicit `NODE_AUTH_TOKEN: ''` override (caused ENEEDAUTH)
- Set registry via `npm config set` instead, which doesn't interfere with OIDC

## Root Cause
`actions/setup-node` with `registry-url` writes `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. npm sees this and uses the (empty/invalid) token instead of doing OIDC exchange.

## Test plan
- [ ] CI passes
- [ ] After merge, bump to v0.1.4, tag, verify publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)