### PR TITLE
fix: restore registry-url + release v0.1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,7 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-
-      - name: Configure npm for OIDC publishing
-        run: npm config set registry https://registry.npmjs.org/
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-02-19
+
+### Fixed
+- Fixed npm trusted publisher case-sensitivity (owner must match GitHub exactly)
+- Restored registry-url in setup-node for proper OIDC .npmrc generation
+
 ## [0.1.4] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-scf",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Root cause: npm trusted publisher had lowercase owner. Fixed on npmjs.com. Restored registry-url for OIDC.