### PR TITLE
fix: align write tools with platform API contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-02-19
+
+### Fixed
+- **Breaking fix:** `ImplementationStatus` enum values changed from UPPERCASE to lowercase to match platform API (e.g., `not_started` instead of `NOT_STARTED`)
+- **Breaking fix:** `update_scoped_control` and `get_scoped_control` now use `scf_id` (e.g., `"AST-01"`) instead of UUID — matches the platform's PATCH route
+- `batch_update_controls` schema expanded from 4 fields to 11 fields, matching the platform's updated `BatchScopedControlOperation` schema
+- Tool descriptions updated to clarify `scf_id` usage and lowercase status values
+
 ## [0.1.5] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-scf",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",
   "bin": {

--- a/src/tools/scoped-controls.ts
+++ b/src/tools/scoped-controls.ts
@@ -4,14 +4,14 @@ import { getClient } from "../lib/api-client.js";
 import { errorResult } from "../lib/errors.js";
 
 const ImplementationStatus = z.enum([
-  "NOT_STARTED",
-  "IN_PROGRESS",
-  "IMPLEMENTED",
-  "READY_FOR_REVIEW",
-  "MONITORED",
-  "NOT_APPLICABLE",
-  "AT_RISK",
-  "DEFERRED",
+  "not_started",
+  "in_progress",
+  "implemented",
+  "ready_for_review",
+  "monitored",
+  "not_applicable",
+  "at_risk",
+  "deferred",
 ]);
 
 export function registerScopedControlTools(server: McpServer) {
@@ -45,15 +45,15 @@ export function registerScopedControlTools(server: McpServer) {
 
   server.tool(
     "get_scoped_control",
-    "Get detailed implementation status of a specific scoped control, including owner, notes, evidence links, and audit history.",
+    "Get detailed implementation status of a specific scoped control, including owner, notes, evidence links, and audit history. Use the scf_id (e.g., 'AST-01') as the identifier.",
     {
       org_id: z.string().describe("Organization ID"),
-      scoped_control_id: z.string().describe("Scoped control ID"),
+      scf_id: z.string().describe("SCF control identifier (e.g., 'AST-01', 'GOV-02') — NOT the UUID"),
     },
-    async ({ org_id, scoped_control_id }) => {
+    async ({ org_id, scf_id }) => {
       try {
         const client = getClient();
-        const data = await client.get(`/organizations/${org_id}/scoped-controls/${scoped_control_id}`);
+        const data = await client.get(`/organizations/${org_id}/scoped-controls/${scf_id}`);
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       } catch (error) {
         return errorResult(error);
@@ -63,11 +63,11 @@ export function registerScopedControlTools(server: McpServer) {
 
   server.tool(
     "update_scoped_control",
-    "Update a scoped control's implementation tracking fields. Status transitions are validated (e.g., NOT_STARTED -> IN_PROGRESS -> IMPLEMENTED). All fields are optional — only provided fields are updated.",
+    "Update a scoped control's implementation tracking fields. Use the scf_id (e.g., 'AST-01', 'GOV-02') as the identifier — NOT the UUID. Status values are lowercase (e.g., 'not_started', 'in_progress'). All fields are optional — only provided fields are updated.",
     {
       org_id: z.string().describe("Organization ID"),
-      scoped_control_id: z.string().describe("Scoped control ID"),
-      implementation_status: ImplementationStatus.optional().describe("New implementation status"),
+      scf_id: z.string().describe("SCF control identifier (e.g., 'AST-01', 'GOV-02') — NOT the UUID"),
+      implementation_status: ImplementationStatus.optional().describe("New implementation status (lowercase: not_started, in_progress, implemented, ready_for_review, monitored, not_applicable, at_risk, deferred)"),
       priority: z.string().optional().describe("Implementation priority (e.g., 'high', 'medium', 'low')"),
       maturity_level: z.string().optional().describe("Control maturity level"),
       owner: z.string().optional().describe("Control owner (person accountable)"),
@@ -75,12 +75,12 @@ export function registerScopedControlTools(server: McpServer) {
       implementation_notes: z.string().optional().describe("Implementation notes and context"),
       target_date: z.string().optional().describe("Target completion date (YYYY-MM-DD)"),
       completion_date: z.string().optional().describe("Actual completion date (YYYY-MM-DD)"),
-      selection_reason: z.string().optional().describe("Justification for scoping selection or status (required for NOT_APPLICABLE, DEFERRED)"),
+      selection_reason: z.string().optional().describe("Justification for scoping selection or status (required for not_applicable, deferred)"),
     },
-    async ({ org_id, scoped_control_id, ...fields }) => {
+    async ({ org_id, scf_id, ...fields }) => {
       try {
         const client = getClient();
-        const data = await client.patch(`/organizations/${org_id}/scoped-controls/${scoped_control_id}`, fields);
+        const data = await client.patch(`/organizations/${org_id}/scoped-controls/${scf_id}`, fields);
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       } catch (error) {
         return errorResult(error);
@@ -127,16 +127,23 @@ export function registerScopedControlTools(server: McpServer) {
 
   server.tool(
     "batch_update_controls",
-    "Batch update multiple scoped controls in a single transaction. Maximum 500 operations per request. Useful for bulk status changes or assignments.",
+    "Batch update multiple scoped controls in a single transaction. Maximum 500 operations per request. Use scf_id (e.g., 'AST-01') to identify controls. Status values must be lowercase.",
     {
       org_id: z.string().describe("Organization ID"),
       operations: z
         .array(
           z.object({
-            scoped_control_id: z.string().describe("Scoped control ID"),
-            status: ImplementationStatus.optional(),
-            owner: z.string().optional(),
-            notes: z.string().optional(),
+            scf_id: z.string().describe("SCF control identifier (e.g., 'AST-01') — required"),
+            selected: z.boolean().optional().describe("Whether the control is in scope"),
+            implementation_status: ImplementationStatus.optional().describe("Implementation status (lowercase)"),
+            selection_reason: z.string().optional().describe("Justification for selection or status"),
+            priority: z.string().optional().describe("Implementation priority"),
+            owner: z.string().optional().describe("Control owner"),
+            assigned_to: z.string().optional().describe("Assignee"),
+            maturity_level: z.string().optional().describe("Control maturity level"),
+            target_date: z.string().optional().describe("Target date (YYYY-MM-DD)"),
+            completion_date: z.string().optional().describe("Completion date (YYYY-MM-DD)"),
+            implementation_notes: z.string().optional().describe("Implementation notes"),
           }),
         )
         .min(1)


### PR DESCRIPTION
## Summary

Fixes all three P0 write endpoint bugs reported in #9 from live integration testing:

- **Enum casing:** `ImplementationStatus` values changed from UPPERCASE (`NOT_STARTED`) to lowercase (`not_started`) to match platform's `ImplementationStatusEnum`
- **Path parameter:** `update_scoped_control` and `get_scoped_control` now use `scf_id` (e.g., `"AST-01"`) instead of UUID — matches the platform's `PATCH /scoped-controls/{scf_id}` route
- **Batch schema:** `batch_update_controls` expanded from 4 fields to 11 fields (scf_id, selected, implementation_status, selection_reason, priority, owner, assigned_to, maturity_level, target_date, completion_date, implementation_notes) matching the platform's updated `BatchScopedControlOperation`

## Test plan

- [ ] `update_scoped_control` with `scf_id: "AST-01"` returns 200 (was 404)
- [ ] `batch_update_controls` with lowercase `implementation_status: "in_progress"` returns 200 (was 422)
- [ ] `get_scoped_control` with `scf_id` returns control details
- [ ] `list_scoped_controls` with lowercase status filter works
- [ ] `npm run build` passes with zero errors

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)