### PR TITLE
fix: version-bump creates PR instead of direct push

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,57 +3,70 @@ name: Publish to npm
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Git tag to publish (e.g., v0.1.6)'
-        required: true
+      version:
+        description: 'Version to publish (e.g., 0.1.7) — reads from package.json on main if empty'
+        required: false
         type: string
 
 permissions:
-  contents: read
+  contents: write  # Needed to create tags
   id-token: write  # Required for npm OIDC trusted publishing
 
 jobs:
-  validate:
-    name: Validate Tag
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
-
-      - name: Validate tag exists and matches package.json
-        run: |
-          TAG_VERSION="${{ inputs.tag }}"
-          TAG_VERSION="${TAG_VERSION#v}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "Version validated: $TAG_VERSION"
-
-      - name: Check not already published
-        run: |
-          TAG_VERSION="${{ inputs.tag }}"
-          TAG_VERSION="${TAG_VERSION#v}"
-          if npm view "mcp-server-scf@$TAG_VERSION" version 2>/dev/null; then
-            echo "::error::Version $TAG_VERSION is already published to npm"
-            exit 1
-          fi
-          echo "Version $TAG_VERSION not yet published — good to go"
-
   publish:
     name: Publish
-    needs: validate
     runs-on: ubuntu-latest
     environment: npm  # Link to GitHub Environment for OIDC
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          INPUT_VERSION="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $VERSION"
+
+      - name: Validate version matches package.json
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "${{ steps.version.outputs.version }}" != "$PKG_VERSION" ]; then
+            echo "::error::Requested version (${{ steps.version.outputs.version }}) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Check not already published
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if npm view "mcp-server-scf@$VERSION" version 2>/dev/null; then
+            echo "::error::Version $VERSION is already published to npm"
+            exit 1
+          fi
+          echo "Version $VERSION not yet published — good to go"
+
+      - name: Create tag if missing
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+          else
+            echo "Creating tag $TAG"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -77,12 +90,20 @@ jobs:
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
 
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Summary
         run: |
-          TAG_VERSION="${{ inputs.tag }}"
-          TAG_VERSION="${TAG_VERSION#v}"
+          VERSION="${{ steps.version.outputs.version }}"
           echo "## Published to npm" >> "$GITHUB_SUMMARY"
           echo "" >> "$GITHUB_SUMMARY"
-          echo "- **Package:** [mcp-server-scf@$TAG_VERSION](https://www.npmjs.com/package/mcp-server-scf/v/$TAG_VERSION)" >> "$GITHUB_SUMMARY"
-          echo "- **Tag:** ${{ inputs.tag }}" >> "$GITHUB_SUMMARY"
+          echo "- **Package:** [mcp-server-scf@$VERSION](https://www.npmjs.com/package/mcp-server-scf/v/$VERSION)" >> "$GITHUB_SUMMARY"
+          echo "- **Tag:** v$VERSION" >> "$GITHUB_SUMMARY"
           echo "- **Provenance:** ✅ Signed" >> "$GITHUB_SUMMARY"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
@@ -27,7 +28,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -63,29 +63,40 @@ jobs:
           - $ENTRY\\
           " CHANGELOG.md
 
-      - name: Commit, tag, and push
+      - name: Create release branch and PR
+        id: pr
         run: |
           VERSION="${{ steps.version.outputs.new }}"
+          BRANCH="release/v$VERSION"
+          git checkout -b "$BRANCH"
           git add package.json package-lock.json CHANGELOG.md
-          git commit -m "chore: bump version to $VERSION"
-          git tag "v$VERSION"
-          git push origin main --tags
+          git commit -m "chore: release v$VERSION"
+          git push origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore: release v$VERSION" \
+            --body "Automated version bump: ${{ steps.version.outputs.old }} → $VERSION
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.version.outputs.new }}
-          name: v${{ steps.version.outputs.new }}
-          generate_release_notes: true
+          **Changelog:** ${{ inputs.changelog }}
+
+          Once merged, run **Publish to npm** with tag \`v$VERSION\` to publish." \
+            --head "$BRANCH" \
+            --base main)
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "Created PR: $PR_URL"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |
-          echo "## Version Bump Complete" >> "$GITHUB_SUMMARY"
+          echo "## Version Bump PR Created" >> "$GITHUB_SUMMARY"
           echo "" >> "$GITHUB_SUMMARY"
+          echo "- **Bump:** ${{ inputs.bump }}" >> "$GITHUB_SUMMARY"
           echo "- **Old:** ${{ steps.version.outputs.old }}" >> "$GITHUB_SUMMARY"
           echo "- **New:** ${{ steps.version.outputs.new }}" >> "$GITHUB_SUMMARY"
-          echo "- **Tag:** v${{ steps.version.outputs.new }}" >> "$GITHUB_SUMMARY"
+          echo "- **PR:** ${{ steps.pr.outputs.url }}" >> "$GITHUB_SUMMARY"
           echo "" >> "$GITHUB_SUMMARY"
-          echo "To publish to npm, run the **Publish to npm** workflow with tag \`v${{ steps.version.outputs.new }}\`." >> "$GITHUB_SUMMARY"
+          echo "Merge the PR, then tag and publish:" >> "$GITHUB_SUMMARY"
+          echo '```bash' >> "$GITHUB_SUMMARY"
+          echo "git tag v${{ steps.version.outputs.new }}" >> "$GITHUB_SUMMARY"
+          echo "git push origin v${{ steps.version.outputs.new }}" >> "$GITHUB_SUMMARY"
+          echo '```' >> "$GITHUB_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,34 +39,30 @@ Releases use two separate GitHub Actions workflows — version bumping and npm p
 
 ### Step 1: Version Bump
 
-Go to **Actions → Version Bump → Run workflow** and select:
+Go to **Actions → Version Bump → Run workflow** and provide:
 - **Bump type:** patch, minor, or major
 - **Changelog entry:** what changed
 
-This will:
-- Bump `package.json` version
-- Update `CHANGELOG.md`
-- Commit, tag (`vX.Y.Z`), and push to main
-- Create a GitHub Release with auto-generated notes
+This creates a PR with the bumped version and updated CHANGELOG. Merge the PR to main.
 
 ### Step 2: Publish to npm
 
-Go to **Actions → Publish to npm → Run workflow** and enter:
-- **Tag:** the git tag from Step 1 (e.g., `v0.2.0`)
+Go to **Actions → Publish to npm → Run workflow**. The version is read from `package.json` on main automatically (or you can override it).
 
 This will:
-- Check out the tagged commit
-- Validate the tag matches `package.json`
+- Validate the version matches `package.json`
 - Verify the version isn't already published
+- Create a git tag if one doesn't exist
 - Build, lint, type-check
 - Publish to npm with [provenance attestation](https://docs.npmjs.com/generating-provenance-statements)
+- Create a GitHub Release
 
 ### Why two steps?
 
-The version bump creates a tag and GitHub Release immediately. Publishing to npm is a separate, manual decision. This lets you:
-- Review the release notes before publishing
-- Hold a version if issues are found after tagging
-- Re-run the publish if it fails without re-tagging
+Version bumping goes through a PR (respects branch protection). Publishing to npm is a separate manual trigger. This lets you:
+- Batch multiple merges before bumping the version
+- Review the version PR before merging
+- Publish when ready, not on every merge
 
 ### Security
 


### PR DESCRIPTION
## Summary
- Version-bump workflow now creates a release branch + PR instead of pushing directly to main (fixes `GH006: Protected branch update failed`)
- npm-publish workflow auto-reads version from package.json, creates tags if missing, and generates GitHub Releases
- Updated CONTRIBUTING.md with the two-step release process

## What changed
**version-bump.yml:** Creates `release/vX.Y.Z` branch, commits version bump + CHANGELOG update, opens PR via `gh pr create`

**npm-publish.yml:** Version input is now optional (reads from package.json). Creates git tag if missing. Creates GitHub Release after successful publish.

## Test plan
- [ ] Merge this PR
- [ ] Run "Version Bump" workflow with `patch` bump type
- [ ] Verify it creates a release PR (not a direct push)
- [ ] Merge the release PR
- [ ] Run "Publish to npm" workflow
- [ ] Verify npm publish succeeds with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)