### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-02-19
+
+### Changed
+- Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases
+
 ## [0.1.6] - 2026-02-19
 
 ### Fixed
@@ -13,26 +18,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `batch_update_controls` schema expanded from 4 fields to 11 fields, matching the platform's updated `BatchScopedControlOperation` schema
 - Tool descriptions updated to clarify `scf_id` usage and lowercase status values
 
+## [0.1.7] - 2026-02-19
+
+### Changed
+- Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases
+
 ## [0.1.5] - 2026-02-19
 
 ### Fixed
 - Fixed npm trusted publisher case-sensitivity (owner must match GitHub exactly)
 - Restored registry-url in setup-node for proper OIDC .npmrc generation
 
+## [0.1.7] - 2026-02-19
+
+### Changed
+- Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases
+
 ## [0.1.4] - 2026-02-19
 
 ### Fixed
 - Removed registry-url from setup-node to allow npm native OIDC exchange
+
+## [0.1.7] - 2026-02-19
+
+### Changed
+- Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases
 
 ## [0.1.3] - 2026-02-19
 
 ### Fixed
 - Fixed OIDC token conflict with setup-node's default NODE_AUTH_TOKEN
 
+## [0.1.7] - 2026-02-19
+
+### Changed
+- Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases
+
 ## [0.1.2] - 2026-02-19
 
 ### Fixed
 - Release workflow now uses Node 24 (required for npm OIDC trusted publishing)
+
+## [0.1.7] - 2026-02-19
+
+### Changed
+- Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases
 
 ## [0.1.1] - 2026-02-19
 
@@ -45,6 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Gitleaks secret detection, CodeQL analysis, Semgrep SAST
 - Dependabot: Weekly dependency and GitHub Actions updates
 - Branch protection with required status checks
+
+## [0.1.7] - 2026-02-19
+
+### Changed
+- Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases
 
 ## [0.1.0] - 2026-02-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-server-scf",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-server-scf",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-scf",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Automated version bump: 0.1.6 → 0.1.7

**Changelog:** Version-bump workflow now creates PR instead of direct push; npm-publish auto-detects version and creates GitHub Releases

Once merged, run **Publish to npm** to publish.