### PR TITLE
fix: use POST upsert for update_evidence instead of PATCH

### DIFF
--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -120,7 +120,13 @@ export function registerEvidenceTools(server: McpServer) {
     async ({ org_id, evidence_id, ...fields }) => {
       try {
         const client = getClient();
-        const data = await client.patch(`/organizations/${org_id}/evidence-tracking/${evidence_id}`, fields);
+        // POST (upsert) instead of PATCH — creates the tracking record if it
+        // doesn't exist yet, updates if it does.  PATCH returns 404 for evidence
+        // items that haven't been activated via the UI.
+        const data = await client.post(`/organizations/${org_id}/evidence-tracking`, {
+          evidence_id,
+          ...fields,
+        });
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       } catch (error) {
         return errorResult(error);


### PR DESCRIPTION
## Summary

- `update_evidence` MCP tool used PATCH (`/evidence-tracking/{id}`) which returns 404 for evidence items without an existing tracking record
- Changed to POST (`/evidence-tracking`) which hits the platform's upsert endpoint — creates if not exists, updates if it does
- Discovered during AAT evidence setup: 10 E-AAT evidence objects existed in the catalog but had no tracking records, so `update_evidence` couldn't reach them

## Test plan

- [ ] Build succeeds (`npm run build`)
- [ ] `update_evidence` on an existing tracked evidence item still updates correctly (regression)
- [ ] `update_evidence` on an unactivated evidence item creates the tracking record (the fix)
- [ ] Verify via `list_evidence` that newly created records appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)