### PR TITLE
feat(capabilities): add 4 KSI scoring + theme drill-down tools (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `get_capability_theme_scorecard` tool — multi-axis KSI scorecard for all capability themes in a single call. Returns per-theme Implementation Coverage, Maturity, Evidence Coverage, Evidence Quality, and composite KSI Posture Score (KPS) with Strong/Moderate/Developing bands. Wraps `GET /organizations/{org_id}/capability-themes/scorecard` (scf-controls-platform #549 Phase 1).
+- `get_capability_theme` tool — single capability theme (KSI) with full posture, multi-axis scores, bands, and legacy `posture_percentage`. Wraps `GET /organizations/{org_id}/capability-themes/{theme_code}`.
+- `list_capability_theme_controls` tool — SCF controls mapped to a capability theme with scoping status, implementation status, and maturity level. Supports pagination (`limit`, `offset`) and scope filtering (`scope_status`). Wraps `GET /organizations/{org_id}/capability-themes/{theme_code}/controls`.
+- `get_capability_theme_evidence_posture` tool — per-theme evidence assessment rollup (file counts by status, average relevance score, derived evidence confidence). Wraps `GET /organizations/{org_id}/capability-themes/evidence-posture`.
+
+Closes #50.
+
 ## [0.5.0] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -518,6 +518,43 @@ List the 11 KSI-aligned capability themes for an organization. Capability themes
 |-----------|------|----------|-------------|
 | `org_id` | string | Yes | Organization ID (UUID) |
 
+#### `get_capability_theme_scorecard`
+
+Multi-axis KSI scorecard for all capability themes in one call. Returns per-theme Implementation Coverage, Maturity, Evidence Coverage, Evidence Quality, and composite KSI Posture Score (KPS) with `Strong`/`Moderate`/`Developing` bands. Supersedes the dual-call pattern of `list_capability_themes` + `get_capability_theme_evidence_posture`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `org_id` | string | Yes | Organization ID (UUID) |
+
+#### `get_capability_theme`
+
+Get a single capability theme (KSI) with full posture, multi-axis scores, bands, and legacy `posture_percentage`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `org_id` | string | Yes | Organization ID (UUID) |
+| `theme_code` | string | Yes | Capability theme code (e.g. `ACCESS_CONTROL`) |
+
+#### `list_capability_theme_controls`
+
+List SCF controls mapped to a capability theme (KSI) with their scoping status, implementation status, and maturity level. Useful for drilling from a KSI into its underlying controls.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `org_id` | string | Yes | Organization ID (UUID) |
+| `theme_code` | string | Yes | Capability theme code (e.g. `ACCESS_CONTROL`) |
+| `scope_status` | string | No | Filter: `in_scope` (default), `out_of_scope`, `all` |
+| `limit` | number | No | Max results per page (default: 50, max: 200) |
+| `offset` | number | No | Pagination offset (default: 0) |
+
+#### `get_capability_theme_evidence_posture`
+
+Per-theme evidence assessment metrics: controls with evidence, file counts by assessment status (sufficient/partial/insufficient/pending/unassessed), average relevance score, and derived evidence confidence level.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `org_id` | string | Yes | Organization ID (UUID) |
+
 #### `list_capabilities`
 
 List security capabilities mapped to systems and evidence, showing what security functions your infrastructure supports.

--- a/src/tools/capabilities.ts
+++ b/src/tools/capabilities.ts
@@ -112,4 +112,98 @@ export function registerCapabilityTools(server: McpServer) {
       }
     },
   );
+
+  // ---------------------------------------------------------------------------
+  // KSI (Capability Theme) Scoring — issue #50
+  // Wraps multi-axis endpoints shipped in scf-controls-platform #549 Phase 1.
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "get_capability_theme_scorecard",
+    "Get the multi-axis KSI scorecard for all capability themes in one call. Returns per-theme Implementation Coverage, Maturity, Evidence Coverage, Evidence Quality, and composite KSI Posture Score (KPS) with Strong/Moderate/Developing bands. Replaces the dual-call pattern of list_capability_themes + evidence-posture. Source: scf-controls-platform #549 Phase 1.",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+    },
+    async ({ org_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/capability-themes/scorecard`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "get_capability_theme",
+    "Get a single capability theme (KSI) with full posture, multi-axis scores, bands, and legacy posture_percentage. Use theme_code from list_capability_themes (e.g., 'ACCESS_CONTROL').",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+      theme_code: z.string().describe("Capability theme code (e.g., 'ACCESS_CONTROL') — get from list_capability_themes"),
+    },
+    async ({ org_id, theme_code }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/capability-themes/${theme_code}`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "list_capability_theme_controls",
+    "List SCF controls mapped to a capability theme (KSI) with their scoping status, implementation status, and maturity level. Use to enumerate controls under a KSI for drill-down into evidence. Supports pagination and scope filtering.",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+      theme_code: z.string().describe("Capability theme code (e.g., 'ACCESS_CONTROL') — get from list_capability_themes"),
+      scope_status: z
+        .enum(["in_scope", "out_of_scope", "all"])
+        .optional()
+        .default("in_scope")
+        .describe("Filter by scoping status (default: in_scope)"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(200)
+        .optional()
+        .default(50)
+        .describe("Max results per page (default: 50, max: 200)"),
+      offset: z.number().int().min(0).optional().default(0).describe("Pagination offset (default: 0)"),
+    },
+    async ({ org_id, theme_code, scope_status, limit, offset }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(
+          `/organizations/${org_id}/capability-themes/${theme_code}/controls`,
+          { scope_status, limit, offset },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "get_capability_theme_evidence_posture",
+    "Get per-theme evidence assessment metrics — controls with evidence, file counts by assessment status (sufficient/partial/insufficient/pending/unassessed), average relevance score, and derived evidence confidence level (strong/moderate/weak/none). Use for KSI-centric evidence quality dashboards.",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+    },
+    async ({ org_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(
+          `/organizations/${org_id}/capability-themes/evidence-posture`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Closes #50. Adds four wrapper tools around the multi-axis capability-theme endpoints shipped in `scf-controls-platform` #549 Phase 1, enabling KSI-first workflows for MCP consumers (e.g. the ComplianceGenieGRC skill).

| New tool | Endpoint | Purpose |
|---|---|---|
| `get_capability_theme_scorecard` | `GET /organizations/{org_id}/capability-themes/scorecard` | Per-theme IC / Maturity / EC / EQ + composite KPS with Strong/Moderate/Developing bands |
| `get_capability_theme` | `GET /organizations/{org_id}/capability-themes/{theme_code}` | Single KSI with full posture + multi-axis scores + legacy `posture_percentage` |
| `list_capability_theme_controls` | `GET /organizations/{org_id}/capability-themes/{theme_code}/controls` | Controls under a KSI with scope filter + pagination |
| `get_capability_theme_evidence_posture` | `GET /organizations/{org_id}/capability-themes/evidence-posture` | Per-theme evidence quality rollup |

## Non-goals

- No backend changes — all four endpoints are already live in production.
- No changes to existing tools (`list_capability_themes` etc. untouched — fully backward compatible).
- No version bump. `[Unreleased]` section added to CHANGELOG; release tag is a separate step.

## Test plan

- [x] `npm run build` succeeds (tsc clean)
- [x] `build/tools/capabilities.js` contains all 4 new tool registrations
- [x] Compiled module imports cleanly (`registerCapabilityTools` resolves as function)
- [ ] `npm run lint` — skipped: `eslint` binary is not installed as a devDependency in the repo (pre-existing; script defined but not wired). Not blocking this PR.
- [ ] Live smoke via MCP Inspector against a seeded org once merged — validate each tool returns a 200 JSON payload and field shapes match backend schemas.

## Files changed

- `src/tools/capabilities.ts` — +4 tool registrations appended to `registerCapabilityTools`
- `README.md` — 4 new subsections under "Capabilities & Systems" with parameter tables
- `CHANGELOG.md` — new `[Unreleased]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)