### PR TITLE
feat(evidence): windowed-assessment MCP tools (platform #568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_capability_theme` tool — single capability theme (KSI) with full posture, multi-axis scores, bands, and legacy `posture_percentage`. Wraps `GET /organizations/{org_id}/capability-themes/{theme_code}`.
 - `list_capability_theme_controls` tool — SCF controls mapped to a capability theme with scoping status, implementation status, and maturity level. Supports pagination (`limit`, `offset`) and scope filtering (`scope_status`). Wraps `GET /organizations/{org_id}/capability-themes/{theme_code}/controls`.
 - `get_capability_theme_evidence_posture` tool — per-theme evidence assessment rollup (file counts by status, average relevance score, derived evidence confidence). Wraps `GET /organizations/{org_id}/capability-themes/evidence-posture`.
+- `trigger_window_assessment` tool — queue a windowed AI assessment that scores all evidence files inside a frequency-derived time window as a portfolio against the union of required artifact types across mapped SCF controls. Editor role. Wraps `POST /organizations/{org_id}/evidence/{evidence_id}/assess-window` (scf-controls-platform #568, M1a).
+- `list_window_assessments` tool — list recent windowed assessments for an evidence ID with `limit`/`offset` pagination. Viewer role. Wraps `GET /organizations/{org_id}/evidence/{evidence_id}/window-assessments`.
+- `get_window_assessment` tool — fetch a single windowed assessment by ID with full detail (window bounds, file IDs, coverage, findings, tokens, cost). Viewer role. Wraps `GET /organizations/{org_id}/evidence/window-assessments/{assessment_id}`.
+- `bulk_assess_windows` tool — queue windowed assessments for up to 25 evidence IDs in one call. Editor role. Wraps `POST /organizations/{org_id}/evidence/assess-windows-bulk`.
+- `get_window_assessment_summary` tool — aggregate windowed-assessment metrics (counts by status including the new `insufficient_sample` bucket, average relevance, total cost). Viewer role. Wraps `GET /organizations/{org_id}/evidence/window-assessments/summary`.
 
 Closes #50.
 

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -300,4 +300,128 @@ export function registerEvidenceTools(server: McpServer) {
       }
     },
   );
+
+  // ---------------------------------------------------------------------------
+  // Windowed AI Evidence Assessment (M1a)
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "trigger_window_assessment",
+    "Queue a windowed AI assessment for an evidence item. Scores all files uploaded inside the frequency-derived window as a portfolio against the union of required artifact types across mapped SCF controls. Returns 202 — poll list_window_assessments or get_window_assessment for the result. Requires editor role or higher. Returns 422 if the evidence has no tracking row or no frequency set (use update_evidence to set a frequency like 'daily', 'weekly', 'monthly' first).",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+      evidence_id: z.string().describe("Evidence ID (e.g., 'E-IAM-01') — must have tracking with a frequency set"),
+      assessment_source: z
+        .enum(["on_demand", "auto", "bulk"])
+        .optional()
+        .default("on_demand")
+        .describe("Source of the assessment request"),
+    },
+    async ({ org_id, evidence_id, assessment_source }) => {
+      try {
+        const client = getClient();
+        const data = await client.post(
+          `/organizations/${org_id}/evidence/${evidence_id}/assess-window`,
+          { assessment_source },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "list_window_assessments",
+    "List the most recent windowed AI assessments for a specific evidence ID (newest first). Each entry includes the window boundaries, frequency used, file IDs in the window, source/artifact coverage, status (pending/processing/sufficient/partial/insufficient/insufficient_sample/error), relevance score, findings, and cost. Requires viewer role or higher.",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+      evidence_id: z.string().describe("Evidence ID (e.g., 'E-IAM-01') — get from list_evidence"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(10)
+        .describe("Maximum number of assessments to return (1-100, default 10)"),
+      offset: z.number().int().min(0).optional().default(0).describe("Number of assessments to skip for pagination (default 0)"),
+    },
+    async ({ org_id, evidence_id, limit, offset }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(
+          `/organizations/${org_id}/evidence/${evidence_id}/window-assessments`,
+          { limit, offset },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "get_window_assessment",
+    "Get a single windowed AI assessment by its assessment ID. Returns full detail: window boundaries, frequency, file IDs, source coverage, artifact type coverage, expected artifact types, status, relevance score, findings, summary, model/prompt/window hashes, token counts, cost, and timing. Requires viewer role or higher.",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+      assessment_id: z.string().describe("Windowed assessment ID (UUID) — get from list_window_assessments"),
+    },
+    async ({ org_id, assessment_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(
+          `/organizations/${org_id}/evidence/window-assessments/${assessment_id}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "bulk_assess_windows",
+    "Queue windowed AI assessments for multiple evidence IDs in one call. Capped at 25 evidence IDs per request. Evidence items without a tracking row or without a frequency set are skipped and reported in the response under `skipped_detail`. Returns the counts and lists of queued/skipped evidence IDs. Requires editor role or higher.",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+      evidence_ids: z
+        .array(z.string())
+        .min(1)
+        .max(25)
+        .describe("Evidence IDs to assess (e.g., ['E-IAM-01','E-BCM-11']). Min 1, max 25 per request."),
+    },
+    async ({ org_id, evidence_ids }) => {
+      try {
+        const client = getClient();
+        const data = await client.post(
+          `/organizations/${org_id}/evidence/assess-windows-bulk`,
+          { evidence_ids },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "get_window_assessment_summary",
+    "Get aggregate windowed-assessment metrics for the organisation dashboard. Returns total windows assessed, counts by status (sufficient/partial/insufficient/insufficient_sample/pending/error), average relevance score, and total cost in cents. `insufficient_sample` is a new bucket indicating the content was fine but the window had too few files to prove the controls' required artifact types. Requires viewer role or higher.",
+    {
+      org_id: z.string().describe("Organization ID (UUID) — get from list_organizations"),
+    },
+    async ({ org_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(
+          `/organizations/${org_id}/evidence/window-assessments/summary`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- Wraps the five new windowed multi-artifact evidence assessment endpoints added in [scf-controls-platform #568](https://github.com/MarkAC007/scf-controls-platform/pull/568) (M1a) so AI agents can trigger, list, fetch, bulk-trigger, and summarise portfolio-level assessments from MCP clients.
- Pure additive change to `src/tools/evidence.ts` (+124 lines) + `CHANGELOG.md` (+5 entries). No existing tools modified. No `src/index.ts` change — evidence tools already registered. No version bump.

## New tools

| Tool | Verb | Path | Role | Notes |
|------|------|------|------|-------|
| `trigger_window_assessment` | POST | `/organizations/{org_id}/evidence/{evidence_id}/assess-window` | editor | 202; 422 if no tracking/frequency; body `{ assessment_source }` |
| `list_window_assessments` | GET | `/organizations/{org_id}/evidence/{evidence_id}/window-assessments` | viewer | `limit` 1-100 (default 10), `offset` (default 0) |
| `get_window_assessment` | GET | `/organizations/{org_id}/evidence/window-assessments/{assessment_id}` | viewer | detail by assessment UUID |
| `bulk_assess_windows` | POST | `/organizations/{org_id}/evidence/assess-windows-bulk` | editor | body `{ evidence_ids: string[] }` min 1, max 25 |
| `get_window_assessment_summary` | GET | `/organizations/{org_id}/evidence/window-assessments/summary` | viewer | aggregate incl. new `insufficient_sample` bucket |

## Implementation notes

- Follows the established `evidence.ts` idiom exactly: `getClient()` + `client.get/post` + `errorResult(error)` + JSON text content block. No new abstractions.
- Every Zod param has `.describe()`. Client-side bounds mirror the backend: `limit.max(100)`, `evidence_ids.min(1).max(25)`, `assessment_source` enum (`on_demand`/`auto`/`bulk`).
- Descriptions document role requirements, status codes, and the new `insufficient_sample` status so AI agents have the context needed to interpret results without fetching docs.
- Example IDs (`E-IAM-01`) aligned with `create_evidence`/`update_evidence` convention.

## Test plan

- [x] `npm run build` (tsc) passes cleanly
- [x] All 19 `server.tool(...)` registrations present in `src/tools/evidence.ts` (14 existing + 5 new)
- [x] Paths in compiled `build/tools/evidence.js` match the platform PR spec byte-for-byte
- [ ] Smoke test against staging: `SCF_API_URL=<staging> SCF_API_KEY=... npm run inspector` → invoke each new tool, confirm 200/202 responses and proper error shape on a frequency-less evidence ID
- [ ] After merge: release via existing npm-publish workflow when 0.6.0 cut is decided

## Out of scope

- No version bump / changelog promotion from `[Unreleased]` → `0.6.0` (deferred to release cut decision).
- No shared tool-factory extraction — 75+ existing handlers follow the same inline try/getClient/return idiom; refactoring is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)