### PR TITLE
chore: add CoC and .github templates (Batch C of v0.6.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,118 @@
+name: Bug report
+description: Report a defect in mcp-server-scf
+title: "[bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please redact any API keys, tokens, or customer data from logs before pasting.
+
+        If this is a **security vulnerability**, please use [GitHub Security Advisories](https://github.com/MarkAC007/mcp-server-scf/security/advisories/new) instead of a public issue.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I have redacted API keys, tokens, and PII from all logs below.
+          required: true
+
+  - type: input
+    id: server-version
+    attributes:
+      label: mcp-server-scf version
+      description: Output of `npx mcp-server-scf --version` or the version pinned in your MCP client config.
+      placeholder: "0.6.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mcp-client
+    attributes:
+      label: MCP client
+      options:
+        - Claude Desktop
+        - Claude Code
+        - Cursor
+        - Windsurf
+        - MCP Inspector
+        - Other (please specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: client-version
+    attributes:
+      label: MCP client version
+      placeholder: "Claude Desktop 0.8.x, Claude Code 2.x, etc."
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`.
+      placeholder: "v20.11.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Docker
+    validations:
+      required: true
+
+  - type: input
+    id: api-url
+    attributes:
+      label: SCF_API_URL
+      description: Which platform endpoint are you hitting? (Do NOT paste the API key.)
+      placeholder: "https://eu.scfcontrolsplatform.app"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, numbered steps. Include the exact tool call or natural-language prompt that triggered the bug.
+      placeholder: |
+        1. Configure mcp-server-scf in Claude Desktop with …
+        2. Ask the assistant to …
+        3. Tool call `list_controls` is invoked with …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead? Include any error message verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs (redacted)
+      description: Relevant stderr output from the MCP client. Replace API keys with `scf_REDACTED`.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/MarkAC007/mcp-server-scf/security/advisories/new
+    about: Please report security vulnerabilities privately via GitHub Security Advisories — do not open a public issue.
+  - name: SCF Controls Platform support
+    url: https://scfcontrolsplatform.com/
+    about: For questions about the SCF Controls Platform itself (API keys, billing, account access), contact the platform directly.
+  - name: Model Context Protocol docs
+    url: https://modelcontextprotocol.io
+    about: Questions about the MCP specification or other MCP clients belong upstream.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose a new capability for mcp-server-scf (non-tool enhancements — for new MCP tools, use the "New MCP tool request" template)
+title: "[feat] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for server-level enhancements: transport options, auth flows, logging, packaging, CLI ergonomics, etc.
+
+        For a request to add a **new MCP tool** that wraps a Platform API endpoint, please use the **"New MCP tool request"** template instead.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem are you trying to solve? Who is the end user? Concrete workflows beat abstract descriptions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-api
+    attributes:
+      label: Proposed API or behaviour
+      description: |
+        What would the interface look like? A config key, a new environment variable, a CLI flag, a change to an existing tool's schema — be as specific as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing tools, workarounds, or upstream features you evaluated and why they fell short.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, links, related issues, prior art from other MCP servers.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -1,0 +1,76 @@
+name: New MCP tool request
+description: Request a new MCP tool that wraps an SCF Controls Platform API endpoint
+title: "[tool] Add `"
+labels: ["enhancement", "type/new-tool", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to propose a new tool exposing an SCF Platform API capability through MCP. The more of the fields below you can fill in, the faster it can be scoped and shipped.
+
+  - type: input
+    id: tool-name
+    attributes:
+      label: Proposed tool name
+      description: "`snake_case`, matches the platform verb/resource (e.g. `list_foo`, `get_foo`, `create_foo`, `trigger_foo`)."
+      placeholder: "list_new_thing"
+    validations:
+      required: true
+
+  - type: textarea
+    id: purpose
+    attributes:
+      label: What should the tool do?
+      description: One-paragraph description of the capability from the AI assistant's point of view. Include the natural-language prompt that would trigger it.
+    validations:
+      required: true
+
+  - type: input
+    id: platform-endpoint
+    attributes:
+      label: Platform API endpoint
+      description: The REST endpoint this tool should wrap, if known.
+      placeholder: "GET /api/v1/orgs/:orgId/new_thing"
+    validations:
+      required: false
+
+  - type: textarea
+    id: inputs
+    attributes:
+      label: Input parameters
+      description: |
+        List each parameter with type, required/optional, and a one-line description. This maps directly to the Zod schema.
+      placeholder: |
+        - org_id (string, required) — Organization ID (UUID)
+        - status (string, optional) — Filter by status
+        - limit (number, optional, default 25, max 100) — Page size
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: outputs
+    attributes:
+      label: Expected output
+      description: Shape of the data returned to the model. Paste a representative API response if you have one (redact secrets).
+    validations:
+      required: true
+
+  - type: dropdown
+    id: read-write
+    attributes:
+      label: Read or write?
+      options:
+        - Read-only
+        - Write (creates or mutates platform state)
+        - Trigger (long-running job)
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+      description: What workflow does this unlock that the existing tools cannot?
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for contributing to mcp-server-scf!
+
+Before you open this PR, please make sure:
+  - It targets a single concern (bug fix, feature, docs, chore, etc.).
+  - The pre-commit hook (husky + lint-staged) ran cleanly on your commits.
+  - You have NOT bumped the version in `package.json` or added a CHANGELOG entry by hand — that is handled by the two-step release workflow after merge. See CONTRIBUTING.md §"Release Process".
+-->
+
+## Summary
+
+<!-- What changed, in one or two sentences. -->
+
+## Linked issues
+
+<!-- `Closes #123`, `Refs #456`. Every PR should link at least one issue. -->
+
+Closes #
+
+## Type of change
+
+<!-- Tick one. -->
+
+- [ ] `fix` — bug fix (no breaking change)
+- [ ] `feat` — new functionality (no breaking change)
+- [ ] `feat!` / `fix!` — breaking change
+- [ ] `docs` — documentation only
+- [ ] `chore` — tooling, dependencies, CI, build
+- [ ] `test` — test suite only
+- [ ] `refactor` — internal change, no behaviour change
+
+## Checklist
+
+- [ ] `npm run lint` passes locally.
+- [ ] `npm run format:check` passes locally (or `npm run format` was run).
+- [ ] `npm run build` passes (TypeScript strict mode, no errors).
+- [ ] `npm test` passes locally.
+- [ ] If I added or removed a tool, the tool-count badge / README table reflects the new total and the README tool-count drift check still passes.
+- [ ] New tools follow the existing pattern: `snake_case` name, Zod schema with `.describe()` on every field, errors via `errorResult()`, no `console.log`.
+- [ ] I have **not** edited `package.json` version or `CHANGELOG.md` — the Version Bump workflow will do that after merge.
+- [ ] I have **not** pushed to `main` directly; this PR is from a feature branch.
+
+## Screenshots / sample output
+
+<!-- Optional. For UX-visible changes (error messages, README rendering, MCP Inspector output) a screenshot or paste helps reviewers. -->
+
+## Additional notes
+
+<!-- Anything reviewers should know: trade-offs considered, follow-up work intentionally deferred, risks. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at GitHub Security Advisories at https://github.com/MarkAC007/mcp-server-scf/security/advisories/new. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing! Here's how to get started.
 
+By participating in this project you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) (Contributor Covenant 2.1).
+
 ## Development Setup
 
 1. Fork and clone the repository

--- a/README.md
+++ b/README.md
@@ -661,6 +661,8 @@ SCF_API_KEY=scf_your_key npx @modelcontextprotocol/inspector node build/index.js
 
 Contributions welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting PRs.
 
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) — see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
 1. Fork the repository
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'Add amazing feature'`)


### PR DESCRIPTION
## Summary

Batch C of the v0.6.0 professional-review workstream. Adds the community-health files GitHub looks for when scoring repo health, and routes security reports into the private SECURITY.md intake instead of public issues.

## Linked issues

Closes #70
Closes #71

## What's in the box

- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 verbatim. Enforcement reports route to [GitHub Security Advisories](https://github.com/MarkAC007/mcp-server-scf/security/advisories/new), matching the pattern already in SECURITY.md (option A from the batch plan — single private intake channel).
- **.github/ISSUE_TEMPLATE/bug.yml** — structured form: server version, MCP client + version, Node, OS, ``SCF_API_URL``, repro, expected/actual, redacted logs. Includes a mandatory "I have redacted API keys, tokens, and PII" checkbox.
- **.github/ISSUE_TEMPLATE/feature.yml** — server-level enhancements (transports, auth, packaging, CLI) — explicitly not for new tools.
- **.github/ISSUE_TEMPLATE/tool-request.yml** — dedicated form for proposing new MCP tools with fields that map directly to Zod schema + ``server.tool()`` registration (snake_case name, platform endpoint, inputs, outputs, read/write/trigger).
- **.github/ISSUE_TEMPLATE/config.yml** — ``blank_issues_enabled: false`` plus ``contact_links`` routing security reports to advisories, platform questions to scfcontrolsplatform.com, and MCP-spec questions to modelcontextprotocol.io.
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist tied to the two-step release workflow documented in [CONTRIBUTING.md:52](CONTRIBUTING.md). Explicitly tells contributors **not** to bump ``package.json`` or edit ``CHANGELOG.md`` by hand — the Version Bump workflow handles that after merge. Also reminds them the README tool-count drift check is active.
- **README.md** + **CONTRIBUTING.md** — link the CoC.

## Decisions worth noting

- **CoC contact = GitHub Security Advisories** (option A agreed up-front). Avoids introducing a new email surface and keeps a single private intake channel. Happy to swap to a dedicated address later if CoC-specific triage diverges from security triage.
- No changes under ``.github/workflows/`` — the claude-review action's OIDC check needs exact-match with main.

## Test plan

Local checks all green before push:

- [x] ``npm run format:check`` — clean
- [x] ``npm run lint`` — 0 errors (the two pre-existing ``@typescript-eslint/no-explicit-any`` warnings in ``src/tools/vendors.ts`` are unchanged)
- [x] ``npm run build`` — tsc strict passes
- [x] ``npm test`` — 29/29 pass
- [x] Husky pre-commit hook ran on commit (lint-staged)
- [ ] CI green on this PR
- [ ] Manual spot-check in the GitHub UI once merged: "New issue" offers the three forms + contact links; "New PR" renders the template