### PR TITLE
docs: split README into docs/ and add troubleshooting (Batch D of v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,39 +23,42 @@ Give your AI assistant access to 1,451 SCF security controls, 354+ framework map
 
 Built for the **[SCF Controls Platform](https://scfcontrolsplatform.com/)**. Maintained by [ComplianceGenie](https://compliancegenie.io).
 
+> Having trouble? → [**docs/troubleshooting.md**](docs/troubleshooting.md) · API key setup → [**docs/authentication.md**](docs/authentication.md) · How it works → [**docs/architecture.md**](docs/architecture.md)
+
 ---
 
 ## Overview
 
 `mcp-server-scf` connects AI assistants to the [SCF Controls Platform](https://scfcontrolsplatform.com/) via MCP, enabling natural language interaction with your compliance program. Your AI can browse the full SCF control catalog, track implementation progress, manage evidence collection, assess risks, and monitor third-party vendors — all without leaving your editor or chat.
 
-**72 tools** across 8 domains:
+**72 tools** across 8 domains — click through for full parameter tables and example prompts:
 
-| Domain                                  | Tools | Description                                                                           |
-| --------------------------------------- | ----- | ------------------------------------------------------------------------------------- |
-| [Catalog](#catalog-reference-data)      | 6     | Browse 1,451 controls, 354+ frameworks, 5,736 assessment objectives                   |
-| [Control Scoping](#control-scoping)     | 6     | Track implementation status across an 8-state workflow                                |
-| [Evidence](#evidence-collection)        | 19    | Manage evidence collection, validation, maturity scoring, and windowed AI assessments |
-| [Risk Management](#risk-management)     | 12    | 5x5 risk matrix, risk register, custom risks and control mapping                      |
-| [Vendor Risk (TPRM)](#vendor-risk-tprm) | 7     | Vendor registry, AI-powered security research, DPSIA                                  |
-| [Organization](#organization--platform) | 7     | Users, orgs, audit trail, work queue, notifications                                   |
-| [Capabilities](#capabilities--systems)  | 9     | KSI capability themes, scorecards, evidence posture, systems inventory                |
-| [Webhooks](#webhooks)                   | 6     | Webhook management, deliveries, secret rotation                                       |
+| Domain                                           | Tools | Description                                                                           |
+| ------------------------------------------------ | ----- | ------------------------------------------------------------------------------------- |
+| [Catalog](docs/tools/catalog.md)                 | 6     | Browse 1,451 controls, 354+ frameworks, 5,736 assessment objectives                   |
+| [Control Scoping](docs/tools/scoped-controls.md) | 6     | Track implementation status across an 8-state workflow                                |
+| [Evidence](docs/tools/evidence.md)               | 19    | Manage evidence collection, validation, maturity scoring, and windowed AI assessments |
+| [Risk Management](docs/tools/risk.md)            | 12    | 5x5 risk matrix, risk register, custom risks and control mapping                      |
+| [Vendor Risk (TPRM)](docs/tools/vendors.md)      | 7     | Vendor registry, AI-powered security research, DPSIA                                  |
+| [Organization](docs/tools/organization.md)       | 7     | Users, orgs, audit trail, work queue, notifications                                   |
+| [Capabilities](docs/tools/capabilities.md)       | 9     | KSI capability themes, scorecards, evidence posture, systems inventory                |
+| [Webhooks](docs/tools/webhooks.md)               | 6     | Webhook endpoints, delivery logs, secret rotation                                     |
 
 ---
 
 ## Quick Start
 
-### Getting an API Key
+### 1. Get an API key
 
-1. Sign up at [scfcontrolsplatform.com](https://scfcontrolsplatform.com/)
-2. Go to **Settings > API Keys**
-3. Click **Generate New Key**
-4. Copy the key (shown once) — it starts with `scf_`
+1. Sign up at [scfcontrolsplatform.com](https://scfcontrolsplatform.com/) (or [eu.scfcontrolsplatform.app](https://eu.scfcontrolsplatform.app) for EU data residency).
+2. **Settings → API Keys → Generate New Key.**
+3. Copy the key — shown once. Starts with `scf_`.
 
-### Claude Desktop
+Full walkthrough (rotation, region selection, scopes): [**docs/authentication.md**](docs/authentication.md).
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+### 2. Add the server to your MCP client
+
+**Claude Desktop** — edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
@@ -72,39 +75,17 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-### Claude Code
+**Claude Code:**
 
 ```bash
 claude mcp add scf -- npx -y mcp-server-scf
-```
-
-Then set environment variables in your shell:
-
-```bash
 export SCF_API_KEY="scf_your_api_key_here"
 export SCF_API_URL="https://eu.scfcontrolsplatform.app"
 ```
 
-### Cursor / Windsurf
+**Cursor / Windsurf** — same JSON shape as Claude Desktop in `.cursor/mcp.json` (or the equivalent Windsurf path).
 
-Add to your MCP config (`.cursor/mcp.json` or equivalent):
-
-```json
-{
-  "mcpServers": {
-    "scf": {
-      "command": "npx",
-      "args": ["-y", "mcp-server-scf"],
-      "env": {
-        "SCF_API_KEY": "scf_your_api_key_here",
-        "SCF_API_URL": "https://eu.scfcontrolsplatform.app"
-      }
-    }
-  }
-}
-```
-
-### Docker
+**Docker:**
 
 ```json
 {
@@ -112,9 +93,7 @@ Add to your MCP config (`.cursor/mcp.json` or equivalent):
     "scf": {
       "command": "docker",
       "args": ["run", "-i", "--rm", "-e", "SCF_API_KEY", "markac007/mcp-server-scf"],
-      "env": {
-        "SCF_API_KEY": "scf_your_api_key_here"
-      }
+      "env": { "SCF_API_KEY": "scf_your_api_key_here" }
     }
   }
 }
@@ -131,510 +110,41 @@ Add to your MCP config (`.cursor/mcp.json` or equivalent):
 
 ---
 
-## Tools
-
-### Catalog (Reference Data)
-
-Read-only access to the full SCF control catalog — 1,451 controls, 354+ frameworks, 272 evidence types, and 5,736 assessment objectives.
-
-#### `list_controls`
-
-List SCF security controls with search, domain, and framework filters.
-
-| Parameter   | Type   | Required | Description                                             |
-| ----------- | ------ | -------- | ------------------------------------------------------- |
-| `search`    | string | No       | Search by control title or description                  |
-| `domain`    | string | No       | Filter by domain identifier (e.g., `GOV`, `AST`, `IAC`) |
-| `framework` | string | No       | Filter by framework (e.g., `nist-800-53`, `iso-27001`)  |
-| `limit`     | number | No       | Results to return (default: 25, max: 100)               |
-| `offset`    | number | No       | Results to skip for pagination (default: 0)             |
-
-#### `get_control`
-
-Get detailed information about a specific SCF control including description, mapped frameworks, assessment objectives, and linked evidence items.
-
-| Parameter | Type   | Required | Description                                                 |
-| --------- | ------ | -------- | ----------------------------------------------------------- |
-| `scf_id`  | string | Yes      | SCF control identifier (e.g., `AST-01`, `IAC-15`, `GOV-02`) |
-
-#### `list_frameworks`
-
-List all 354+ compliance frameworks mapped in the SCF catalog (NIST 800-53, ISO 27001, SOC 2, FedRAMP, GDPR, and more).
-
-_No parameters._
-
-#### `list_domains`
-
-List all compliance domains in the SCF taxonomy. Domains group related security controls (e.g., GOV = Governance, AST = Asset Management, IAC = Identity & Access Control).
-
-_No parameters._
-
-#### `list_evidence_catalog`
-
-List the 272 standard evidence types from the SCF reference catalog that can be collected to demonstrate control implementation.
-
-| Parameter | Type   | Required | Description                                 |
-| --------- | ------ | -------- | ------------------------------------------- |
-| `search`  | string | No       | Search by evidence title or description     |
-| `limit`   | number | No       | Results to return (default: 25, max: 100)   |
-| `offset`  | number | No       | Results to skip for pagination (default: 0) |
-
-#### `list_assessment_objectives`
-
-List the 5,736 assessment test criteria used to evaluate control implementation. Can filter by specific control ID.
-
-| Parameter    | Type   | Required | Description                                         |
-| ------------ | ------ | -------- | --------------------------------------------------- |
-| `control_id` | string | No       | Filter by SCF control ID (e.g., `GOV-01`, `AST-02`) |
-| `search`     | string | No       | Search term to filter objectives                    |
-| `limit`      | number | No       | Results to return (default: 25, max: 100)           |
-| `offset`     | number | No       | Results to skip for pagination (default: 0)         |
-
----
-
-### Control Scoping
-
-Track implementation status of controls scoped to your organization. Supports an 8-state workflow: `not_started`, `in_progress`, `implemented`, `ready_for_review`, `monitored`, `not_applicable`, `at_risk`, `deferred`.
-
-#### `list_scoped_controls`
-
-List controls scoped to your organization with implementation status. Supports filtering by status, domain, framework, and search.
-
-| Parameter      | Type   | Required | Description                                                                                                                             |
-| -------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `org_id`       | string | Yes      | Organization ID (UUID) — use `list_organizations` to find                                                                               |
-| `scope_status` | string | No       | Filter by status: `not_started`, `in_progress`, `implemented`, `ready_for_review`, `monitored`, `not_applicable`, `at_risk`, `deferred` |
-| `domain`       | string | No       | Filter by SCF domain (e.g., `GOV`, `AST`, `IAC`)                                                                                        |
-| `framework`    | string | No       | Filter by framework                                                                                                                     |
-| `search`       | string | No       | Search by control ID or title                                                                                                           |
-| `limit`        | number | No       | Results to return (default: 25, max: 100)                                                                                               |
-| `offset`       | number | No       | Results to skip for pagination (default: 0)                                                                                             |
-
-#### `get_scoped_control`
-
-Get detailed implementation status of a specific scoped control, including owner, notes, evidence links, and audit history.
-
-| Parameter | Type   | Required | Description                                       |
-| --------- | ------ | -------- | ------------------------------------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID)                            |
-| `scf_id`  | string | Yes      | SCF control identifier (e.g., `AST-01`, `GOV-02`) |
-
-#### `update_scoped_control`
-
-Update a scoped control's implementation tracking fields. Only provided fields are updated.
-
-| Parameter               | Type   | Required | Description                                                                                                                                   |
-| ----------------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `org_id`                | string | Yes      | Organization ID (UUID)                                                                                                                        |
-| `scf_id`                | string | Yes      | SCF control identifier (e.g., `AST-01`, `GOV-02`)                                                                                             |
-| `implementation_status` | string | No       | New status (lowercase): `not_started`, `in_progress`, `implemented`, `ready_for_review`, `monitored`, `not_applicable`, `at_risk`, `deferred` |
-| `priority`              | string | No       | Priority: `high`, `medium`, `low`                                                                                                             |
-| `maturity_level`        | string | No       | Control maturity level                                                                                                                        |
-| `owner`                 | string | No       | Control owner (person accountable)                                                                                                            |
-| `assigned_to`           | string | No       | Assignee (person responsible for implementation)                                                                                              |
-| `implementation_notes`  | string | No       | Implementation notes and context                                                                                                              |
-| `target_date`           | string | No       | Target completion date (`YYYY-MM-DD`)                                                                                                         |
-| `completion_date`       | string | No       | Actual completion date (`YYYY-MM-DD`)                                                                                                         |
-| `selection_reason`      | string | No       | Justification for status (required for `not_applicable`, `deferred`)                                                                          |
-
-#### `get_scoping_stats`
-
-Get implementation statistics — counts by status, completion percentage, and framework coverage breakdown.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `scope_framework`
-
-Bulk-scope all controls from a framework to your organization. Creates scoped control entries for every control in the selected framework.
-
-| Parameter      | Type   | Required | Description                                    |
-| -------------- | ------ | -------- | ---------------------------------------------- |
-| `org_id`       | string | Yes      | Organization ID (UUID)                         |
-| `framework_id` | string | Yes      | Framework ID to scope (e.g., `nist-800-53-r5`) |
-
-#### `batch_update_controls`
-
-Batch update up to 500 scoped controls in a single transaction.
-
-| Parameter    | Type   | Required | Description                                           |
-| ------------ | ------ | -------- | ----------------------------------------------------- |
-| `org_id`     | string | Yes      | Organization ID (UUID)                                |
-| `operations` | array  | Yes      | Array of update operations (max 500). Each operation: |
-
-Each operation in the `operations` array accepts:
-
-| Field                   | Type    | Required | Description                             |
-| ----------------------- | ------- | -------- | --------------------------------------- |
-| `scf_id`                | string  | Yes      | SCF control identifier (e.g., `AST-01`) |
-| `selected`              | boolean | No       | Whether the control is in scope         |
-| `implementation_status` | string  | No       | Implementation status (lowercase)       |
-| `selection_reason`      | string  | No       | Justification for selection or status   |
-| `priority`              | string  | No       | Implementation priority                 |
-| `owner`                 | string  | No       | Control owner                           |
-| `assigned_to`           | string  | No       | Assignee                                |
-| `maturity_level`        | string  | No       | Control maturity level                  |
-| `target_date`           | string  | No       | Target date (`YYYY-MM-DD`)              |
-| `completion_date`       | string  | No       | Completion date (`YYYY-MM-DD`)          |
-| `implementation_notes`  | string  | No       | Implementation notes                    |
-
----
-
-### Evidence Collection
-
-Track evidence artifacts that demonstrate control implementation for audit readiness.
-
-#### `list_evidence`
-
-List evidence items tracked for an organization's controls.
-
-| Parameter   | Type   | Required | Description            |
-| ----------- | ------ | -------- | ---------------------- |
-| `org_id`    | string | Yes      | Organization ID (UUID) |
-| `system_id` | string | No       | Filter by system ID    |
-
-#### `create_evidence`
-
-Create a new evidence item linked to a control.
-
-| Parameter       | Type   | Required | Description                                 |
-| --------------- | ------ | -------- | ------------------------------------------- |
-| `org_id`        | string | Yes      | Organization ID (UUID)                      |
-| `title`         | string | Yes      | Evidence title                              |
-| `control_id`    | string | No       | Scoped control ID to link evidence to       |
-| `description`   | string | No       | Evidence description                        |
-| `evidence_type` | string | No       | Type: `document`, `screenshot`, `log`, etc. |
-
-#### `get_evidence_maturity`
-
-Get evidence maturity summary — average maturity score, automation percentage, distribution by maturity level, and improvement opportunities.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `list_evidence_tasks`
-
-List evidence collection tasks — the work queue for gathering evidence. Shows what needs to be collected, by whom, and by when.
-
-| Parameter  | Type   | Required | Description             |
-| ---------- | ------ | -------- | ----------------------- |
-| `org_id`   | string | No       | Organization ID (UUID)  |
-| `assignee` | string | No       | Filter by assigned user |
-| `status`   | string | No       | Filter by task status   |
-
----
-
-### Risk Management
-
-5x5 risk matrix with inherent and residual scoring, treatment tracking, and severity summaries.
-
-#### `list_risks`
-
-List risk assessments in the organization's risk register.
-
-| Parameter  | Type   | Required | Description                              |
-| ---------- | ------ | -------- | ---------------------------------------- |
-| `org_id`   | string | Yes      | Organization ID (UUID)                   |
-| `status`   | string | No       | Filter by treatment status               |
-| `page`     | number | No       | Page number (default: 1)                 |
-| `per_page` | number | No       | Results per page (default: 25, max: 100) |
-
-#### `get_risk`
-
-Get detailed risk assessment including inherent and residual scores, treatment plan, owner, and review date.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-| `risk_id` | string | Yes      | Risk assessment ID     |
-
-#### `create_risk`
-
-Create a new risk assessment in the 5x5 risk matrix.
-
-| Parameter          | Type   | Required | Description                                          |
-| ------------------ | ------ | -------- | ---------------------------------------------------- |
-| `org_id`           | string | Yes      | Organization ID (UUID)                               |
-| `title`            | string | Yes      | Risk title                                           |
-| `description`      | string | Yes      | Risk description                                     |
-| `likelihood`       | number | Yes      | Inherent likelihood (1-5)                            |
-| `impact`           | number | Yes      | Inherent impact (1-5)                                |
-| `owner`            | string | No       | Risk owner                                           |
-| `treatment_status` | string | No       | Treatment: `mitigate`, `accept`, `transfer`, `avoid` |
-| `control_id`       | string | No       | Linked control ID                                    |
-
-#### `get_risk_matrix`
-
-Get the 5x5 risk matrix visualization data showing risk distribution across likelihood and impact.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `get_risk_summary`
-
-Get aggregated risk summary — total risks by severity, treatment status breakdown, and trend data.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
----
-
-### Vendor Risk (TPRM)
-
-Third-party risk management with AI-powered security research, breach detection, and data protection impact assessments.
-
-#### `list_vendors`
-
-List vendors in the TPRM registry with status and criticality filters.
-
-| Parameter     | Type   | Required | Description                                  |
-| ------------- | ------ | -------- | -------------------------------------------- |
-| `org_id`      | string | Yes      | Organization ID (UUID)                       |
-| `status`      | string | No       | Filter: `active`, `inactive`, `under_review` |
-| `criticality` | string | No       | Filter: `critical`, `high`, `medium`, `low`  |
-| `page`        | number | No       | Page number (default: 1)                     |
-| `per_page`    | number | No       | Results per page (default: 25, max: 100)     |
-
-#### `get_vendor`
-
-Get detailed vendor information including certifications, assessments, risk score, and research results.
-
-| Parameter   | Type   | Required | Description            |
-| ----------- | ------ | -------- | ---------------------- |
-| `org_id`    | string | Yes      | Organization ID (UUID) |
-| `vendor_id` | string | Yes      | Vendor ID              |
-
-#### `create_vendor`
-
-Add a new vendor to the TPRM registry.
-
-| Parameter       | Type   | Required | Description                                                |
-| --------------- | ------ | -------- | ---------------------------------------------------------- |
-| `org_id`        | string | Yes      | Organization ID (UUID)                                     |
-| `name`          | string | Yes      | Vendor name                                                |
-| `description`   | string | No       | Vendor description                                         |
-| `category`      | string | No       | Category: `SaaS`, `Infrastructure`, `Consulting`, etc.     |
-| `criticality`   | string | No       | Criticality: `critical`, `high`, `medium` (default), `low` |
-| `website`       | string | No       | Vendor website URL                                         |
-| `contact_email` | string | No       | Primary contact email                                      |
-
-#### `trigger_vendor_research`
-
-Trigger AI-powered security research for a vendor — checks HIBP (breach databases), NVD (vulnerability databases), and public security posture.
-
-| Parameter   | Type   | Required | Description            |
-| ----------- | ------ | -------- | ---------------------- |
-| `org_id`    | string | Yes      | Organization ID (UUID) |
-| `vendor_id` | string | Yes      | Vendor ID              |
-
-#### `get_vendor_research`
-
-Get the latest AI-powered research results for a vendor, including breach history, known vulnerabilities, and security posture analysis.
-
-| Parameter   | Type   | Required | Description            |
-| ----------- | ------ | -------- | ---------------------- |
-| `org_id`    | string | Yes      | Organization ID (UUID) |
-| `vendor_id` | string | Yes      | Vendor ID              |
-
-#### `trigger_dpsia`
-
-Trigger a Data Protection Security Impact Assessment (DPSIA) for a vendor. Evaluates security posture against CIA triad and certification requirements.
-
-| Parameter   | Type   | Required | Description            |
-| ----------- | ------ | -------- | ---------------------- |
-| `org_id`    | string | Yes      | Organization ID (UUID) |
-| `vendor_id` | string | Yes      | Vendor ID              |
-
----
-
-### Organization & Platform
-
-User management, audit trail, work queue, and notifications.
-
-#### `get_current_user`
-
-Get the current authenticated user's profile, including name, email, organizations, and role.
-
-_No parameters._
-
-#### `list_organizations`
-
-List organizations the current user has access to. Returns org ID, name, tier, and member count.
-
-_No parameters._
-
-#### `get_organization`
-
-Get detailed organization information including subscription tier, member count, usage limits, and settings.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `list_members`
-
-List members of an organization with their roles (`admin`, `editor`, `viewer`).
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `get_work_queue`
-
-Get the authenticated user's prioritized work queue — pending tasks, assignments, and action items across all organizations.
-
-_No parameters._
-
-#### `get_audit_log`
-
-Get the field-level audit trail for an organization. Shows changes to controls, evidence, and other entities with actor, timestamp, and before/after values.
-
-| Parameter | Type   | Required | Description                                 |
-| --------- | ------ | -------- | ------------------------------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID)                      |
-| `limit`   | number | No       | Results to return (default: 50, max: 100)   |
-| `offset`  | number | No       | Results to skip for pagination (default: 0) |
-
-#### `get_notifications`
-
-Get notifications for the current user — new assignments, comments, status changes, and system alerts.
-
-| Parameter     | Type    | Required | Description                                       |
-| ------------- | ------- | -------- | ------------------------------------------------- |
-| `unread_only` | boolean | No       | Only return unread notifications (default: false) |
-| `limit`       | number  | No       | Notifications to return (default: 25, max: 100)   |
-
----
-
-### Capabilities & Systems
-
-KSI-aligned capability themes and infrastructure systems inventory.
-
-#### `list_capability_themes`
-
-List the 11 KSI-aligned capability themes for an organization. Capability themes group NIST 800-53 controls into security capability areas.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `get_capability_theme_scorecard`
-
-Multi-axis KSI scorecard for all capability themes in one call. Returns per-theme Implementation Coverage, Maturity, Evidence Coverage, Evidence Quality, and composite KSI Posture Score (KPS) with `Strong`/`Moderate`/`Developing` bands. Supersedes the dual-call pattern of `list_capability_themes` + `get_capability_theme_evidence_posture`.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `get_capability_theme`
-
-Get a single capability theme (KSI) with full posture, multi-axis scores, bands, and legacy `posture_percentage`.
-
-| Parameter    | Type   | Required | Description                                   |
-| ------------ | ------ | -------- | --------------------------------------------- |
-| `org_id`     | string | Yes      | Organization ID (UUID)                        |
-| `theme_code` | string | Yes      | Capability theme code (e.g. `ACCESS_CONTROL`) |
-
-#### `list_capability_theme_controls`
-
-List SCF controls mapped to a capability theme (KSI) with their scoping status, implementation status, and maturity level. Useful for drilling from a KSI into its underlying controls.
-
-| Parameter      | Type   | Required | Description                                         |
-| -------------- | ------ | -------- | --------------------------------------------------- |
-| `org_id`       | string | Yes      | Organization ID (UUID)                              |
-| `theme_code`   | string | Yes      | Capability theme code (e.g. `ACCESS_CONTROL`)       |
-| `scope_status` | string | No       | Filter: `in_scope` (default), `out_of_scope`, `all` |
-| `limit`        | number | No       | Max results per page (default: 50, max: 200)        |
-| `offset`       | number | No       | Pagination offset (default: 0)                      |
-
-#### `get_capability_theme_evidence_posture`
-
-Per-theme evidence assessment metrics: controls with evidence, file counts by assessment status (sufficient/partial/insufficient/pending/unassessed), average relevance score, and derived evidence confidence level.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `list_capabilities`
-
-List security capabilities mapped to systems and evidence, showing what security functions your infrastructure supports.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `list_systems`
-
-List infrastructure systems in the organization's inventory.
-
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
-
-#### `create_system`
-
-Add a system to the organization's infrastructure inventory. Systems can be linked to capabilities and evidence.
-
-| Parameter     | Type   | Required | Description                                                                                                                              |
-| ------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `org_id`      | string | Yes      | Organization ID (UUID)                                                                                                                   |
-| `name`        | string | Yes      | System name                                                                                                                              |
-| `system_type` | string | Yes      | Type: `cloud_provider`, `identity_provider`, `ticketing`, `logging`, `security_tool`, `code_repository`, `document_management`, `custom` |
-| `description` | string | No       | System description                                                                                                                       |
-| `status`      | string | No       | Status: `active` (default), `inactive`, `deprecated`                                                                                     |
-
----
-
 ## Example Prompts
 
 Once connected, try asking your AI assistant:
 
 - "What NIST 800-53 controls apply to access control?"
-- "Show me my organization's control implementation progress"
-- "List all critical vendors and their risk scores"
-- "Create a risk assessment for our cloud migration"
+- "Show me my organization's control implementation progress."
+- "List all critical vendors and their risk scores."
+- "Create a risk assessment for our cloud migration."
 - "What evidence do I need to collect for SOC 2 audit?"
-- "Show the 5x5 risk matrix for my organization"
-- "Scope the ISO 27001 framework for my org"
-- "Batch update all access control controls to in_progress"
-- "What's in my compliance work queue today?"
-- "Run a DPSIA on our cloud provider vendor"
+- "Show the 5x5 risk matrix for my organization."
+- "Run a DPSIA on our cloud provider vendor."
+
+More examples live in each per-domain doc under [`docs/tools/`](docs/tools/).
+
+---
+
+## Documentation
+
+- [**docs/authentication.md**](docs/authentication.md) — API key setup, rotation, region selection, scopes.
+- [**docs/architecture.md**](docs/architecture.md) — request flow, error model, rate limiting, what the server does and does not do.
+- [**docs/troubleshooting.md**](docs/troubleshooting.md) — symptom/cause/fix for the common failure modes.
+- [**docs/tools/**](docs/tools/) — per-domain reference with full parameter tables.
 
 ---
 
 ## Security
 
-- API keys are never logged or included in error messages
-- All communication uses HTTPS
-- Keys are SHA-256 hashed server-side
-- Rate limiting: 100 req/min (read), 20 req/min (write)
-- Multi-tenant: all operations scoped to your organization
-- npm package published with [provenance attestation](https://docs.npmjs.com/generating-provenance-statements) via OIDC trusted publishing
-- CI includes Gitleaks secret detection, CodeQL analysis, and Semgrep SAST
+- API keys are never logged or included in error messages.
+- All communication uses HTTPS; keys are SHA-256 hashed server-side.
+- Rate limiting: 100 req/min read, 20 req/min write.
+- Multi-tenant — all operations scoped to your organization.
+- npm package published with [provenance attestation](https://docs.npmjs.com/generating-provenance-statements) via OIDC trusted publishing.
+- CI includes Gitleaks secret detection, CodeQL analysis, and Semgrep SAST.
 
----
-
-## Architecture
-
-```
-src/
-├── index.ts              # Server entry point (stdio transport)
-├── tools/
-│   ├── catalog.ts        # SCF reference data (read-only, 6 tools)
-│   ├── scoped-controls.ts # Control implementation tracking (6 tools)
-│   ├── evidence.ts       # Evidence collection (4 tools)
-│   ├── risk.ts           # Risk register (5 tools)
-│   ├── vendors.ts        # Third-party risk management (7 tools)
-│   ├── organization.ts   # Org, users, audit, notifications (7 tools)
-│   └── capabilities.ts   # KSI themes, systems (4 tools)
-└── lib/
-    ├── api-client.ts     # HTTP client with auth
-    └── errors.ts         # Structured error handling
-```
+See [SECURITY.md](SECURITY.md) to report a vulnerability.
 
 ---
 
@@ -647,6 +157,7 @@ npm install
 npm run build
 npm run dev        # Watch mode
 npm run lint       # ESLint
+npm test           # Vitest
 ```
 
 ### Testing with MCP Inspector
@@ -673,15 +184,15 @@ This project follows the [Contributor Covenant](https://www.contributor-covenant
 
 ## License
 
-MIT - see [LICENSE](LICENSE)
+MIT — see [LICENSE](LICENSE).
 
 ---
 
 ## Links
 
-- [SCF Controls Platform](https://scfcontrolsplatform.com/) — The compliance platform
-- [ComplianceGenie.io](https://compliancegenie.io) — Maintained by Compliance Genie
+- [SCF Controls Platform](https://scfcontrolsplatform.com/) — the compliance platform
+- [ComplianceGenie.io](https://compliancegenie.io) — maintained by Compliance Genie
 - [Model Context Protocol](https://modelcontextprotocol.io) — MCP specification
 - [SCF Framework](https://securecontrolsframework.com) — Secure Controls Framework
 - [npm Package](https://www.npmjs.com/package/mcp-server-scf) — npm registry
-- [Changelog](CHANGELOG.md) — Release history
+- [Changelog](CHANGELOG.md) — release history

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,106 @@
+# Architecture
+
+`mcp-server-scf` is a thin, stateless Node.js process that translates MCP tool calls into HTTP requests against the SCF Controls Platform API. It has no local database, no background jobs, and no caching layer — the platform is the single source of truth.
+
+---
+
+## Process model
+
+The server runs as a child process of the MCP client (Claude Desktop, Claude Code, Cursor, etc.) and communicates over stdio using the MCP framing protocol.
+
+```
+MCP client (Claude Desktop / Code / Cursor)
+      │  (stdio: stdin/stdout, MCP JSON-RPC framing)
+      ▼
+mcp-server-scf  (Node.js ≥18, ESM, single long-lived process)
+      │  (HTTPS, Bearer token)
+      ▼
+SCF Controls Platform API  (eu.scfcontrolsplatform.app by default)
+```
+
+Because stdio is the transport, **anything written to `stdout` corrupts the protocol frame**. All logging in this server goes to `stderr` via `console.error` — including the startup banner ([`src/index.ts:44`](../src/index.ts:44)). When adding new tools, never introduce `console.log` or raw `process.stdout.write` calls.
+
+---
+
+## Source layout
+
+```
+src/
+├── index.ts              Entry point. Constructs McpServer, wires
+│                         StdioServerTransport, calls each register*
+│                         function to attach tools, starts the loop.
+├── tools/
+│   ├── catalog.ts        6 tools — read-only SCF reference data
+│   ├── scoped-controls.ts 6 tools — per-org implementation tracking
+│   ├── evidence.ts       19 tools — CRUD, files, validation, AI
+│   │                     assessments (per-file + windowed)
+│   ├── risk.ts           12 tools — risk register + custom risks
+│   ├── vendors.ts        7 tools — TPRM + AI research + DPSIA
+│   ├── organization.ts   7 tools — user, orgs, audit, notifications
+│   ├── capabilities.ts   9 tools — KSI themes, systems, scorecards
+│   └── webhooks.ts       6 tools — webhook endpoints + deliveries
+└── lib/
+    ├── api-client.ts     ScfApiClient — fetch wrapper with auth,
+    │                     pagination helpers, typed get/post/patch/delete.
+    └── errors.ts         ScfApiError + formatError + errorResult.
+```
+
+Total: **72 tools across 8 domain files**. The per-domain docs live under [`docs/tools/`](tools/).
+
+---
+
+## Request flow
+
+Every tool follows the same shape:
+
+1. **Tool invocation** — the MCP client sends a `tools/call` request with validated arguments (Zod schema enforces types, ranges, and required fields before the handler runs).
+2. **Client construction** — the handler calls `getClient()` ([`src/lib/api-client.ts:104`](../src/lib/api-client.ts:104)), a lazy singleton that reads `SCF_API_KEY` and `SCF_API_URL` from the environment the first time it's called.
+3. **HTTP request** — `client.get|post|patch|delete(path, ...)` issues a `fetch` to `${baseUrl}/api${path}` with `Authorization: Bearer ${apiKey}`. Mutation methods always send `Content-Type: application/json` and a JSON body (at least `{}`) to satisfy FastAPI's Pydantic body-parameter requirement.
+4. **Response handling** — on `2xx`, the JSON body is returned as the tool result. On any non-2xx, `ScfApiError` is thrown with the parsed `detail`/`error`/`message` field and the HTTP status code.
+5. **Error translation** — the handler's `try/catch` pipes thrown errors into `errorResult(error)`, which returns an MCP content array with `isError: true` and a human-readable message via `formatError`.
+
+The client has no retry logic — it's the caller's responsibility to retry on `429` or transient `5xx`.
+
+---
+
+## Error model
+
+All error responses use `isError: true` with a single text block. `ScfApiError` status codes are translated to user-facing messages ([`src/lib/errors.ts:12`](../src/lib/errors.ts:12)):
+
+| Status | Translated message                                                     |
+| ------ | ---------------------------------------------------------------------- |
+| 401    | "Authentication failed. Check your `SCF_API_KEY`."                     |
+| 402    | "Subscription limit reached. Upgrade your plan to continue."           |
+| 403    | "Access denied. Your API key may lack permissions for this operation." |
+| 404    | `Not found: ${error.message}`                                          |
+| 429    | "Rate limited. Please wait before retrying."                           |
+| Other  | `API error (${statusCode}): ${error.message}`                          |
+
+Non-`ScfApiError` errors (network failures, JSON parse errors) fall through to `error.message`. API keys are never logged and never included in the error payload.
+
+---
+
+## Rate limiting
+
+The platform enforces **100 read requests/min and 20 write requests/min** per API key. When exceeded, the server returns `429` and this server surfaces it as "Rate limited. Please wait before retrying." Clients should back off and retry. The server does not implement automatic retry — batch operations (`batch_update_controls`, `bulk_assess_evidence`, `bulk_assess_windows`) exist specifically to avoid hitting these limits when mutating many records.
+
+---
+
+## Configuration
+
+Configuration is environment-only — there is no config file. See [`docs/authentication.md`](authentication.md) for API key setup and region selection.
+
+| Variable      | Required | Default                              | Purpose                                                  |
+| ------------- | -------- | ------------------------------------ | -------------------------------------------------------- |
+| `SCF_API_KEY` | Yes      | —                                    | Bearer token for every request (format: `scf_…`)         |
+| `SCF_API_URL` | No       | `https://eu.scfcontrolsplatform.app` | Platform endpoint; switch to the US endpoint if required |
+
+---
+
+## What this server does **not** do
+
+- No persistent storage. Every request hits the platform.
+- No caching. Successive `list_controls` calls re-fetch.
+- No background jobs. Long-running platform tasks (`trigger_vendor_research`, `trigger_dpsia`, `trigger_window_assessment`) return a task ID; the client polls via the corresponding `get_*` tool.
+- No webhook receiver. `create_webhook` provisions a platform-side endpoint; external systems POST directly to the platform, not to this server.
+- No streaming. All responses are buffered JSON.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,140 @@
+# Authentication
+
+`mcp-server-scf` authenticates to the SCF Controls Platform using a single Bearer token passed as `SCF_API_KEY`. There is no OAuth flow, no session cookie, and no local credential store — the key is read from the environment on first use and attached to every request as `Authorization: Bearer scf_...`.
+
+---
+
+## Getting an API key
+
+1. Sign up or sign in at your region's platform URL:
+   - **EU (default):** [eu.scfcontrolsplatform.app](https://eu.scfcontrolsplatform.app)
+   - **US:** [scfcontrolsplatform.com](https://scfcontrolsplatform.com)
+2. Open **Settings → API Keys**.
+3. Click **Generate New Key**.
+4. Copy the key immediately — it's shown once. Keys are stored server-side as SHA-256 hashes and cannot be recovered after the dialog closes.
+
+### Key format
+
+API keys always start with the `scf_` prefix:
+
+```
+scf_abcdef1234567890…
+```
+
+This prefix lets secret-scanning tools (Gitleaks, GitHub secret scanning, Socket) fingerprint accidental commits. If a key lands in git history, rotate it immediately — the `scf_` prefix is the regex used by upstream scanners, so GitHub will notify the platform.
+
+---
+
+## Providing the key to the server
+
+The server reads the environment only when the first tool is called ([`src/lib/api-client.ts:104`](../src/lib/api-client.ts:104)). Set the key in the MCP client's environment block — not in a shell profile, because MCP clients launch the server as a child process with a minimal environment.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "scf": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-scf"],
+      "env": {
+        "SCF_API_KEY": "scf_your_api_key_here",
+        "SCF_API_URL": "https://eu.scfcontrolsplatform.app"
+      }
+    }
+  }
+}
+```
+
+Config paths:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+### Claude Code
+
+```bash
+claude mcp add scf -- npx -y mcp-server-scf
+export SCF_API_KEY="scf_your_api_key_here"
+export SCF_API_URL="https://eu.scfcontrolsplatform.app"
+```
+
+Claude Code inherits your shell environment, so `export` in your shell profile works here. Claude Desktop does not.
+
+### Cursor / Windsurf
+
+```json
+{
+  "mcpServers": {
+    "scf": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-scf"],
+      "env": {
+        "SCF_API_KEY": "scf_your_api_key_here",
+        "SCF_API_URL": "https://eu.scfcontrolsplatform.app"
+      }
+    }
+  }
+}
+```
+
+Both clients use an `mcp.json` (or equivalent) in the workspace or user config directory.
+
+### Docker
+
+```json
+{
+  "mcpServers": {
+    "scf": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "SCF_API_KEY", "markac007/mcp-server-scf"],
+      "env": {
+        "SCF_API_KEY": "scf_your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+The `-e SCF_API_KEY` flag (without a value) passes the variable through from the client's `env` block into the container — the key itself never appears in the container args list.
+
+---
+
+## Region selection
+
+`SCF_API_URL` selects the platform region. Pick the endpoint that matches where your data is hosted:
+
+| Region | `SCF_API_URL`                                  | Platform console             |
+| ------ | ---------------------------------------------- | ---------------------------- |
+| EU     | `https://eu.scfcontrolsplatform.app` (default) | `eu.scfcontrolsplatform.app` |
+| US     | `https://scfcontrolsplatform.com`              | `scfcontrolsplatform.com`    |
+
+An API key issued in one region **will not work** against the other. Using the wrong URL produces `401 Authentication failed` — the most common cause of a working account reporting auth errors.
+
+---
+
+## Rotation
+
+Platform-side rotation is a two-step process:
+
+1. Generate a new key in **Settings → API Keys**. You'll have two active keys temporarily.
+2. Update the `SCF_API_KEY` value in every MCP client config, restart the client, and verify tools work.
+3. Revoke the old key from the platform.
+
+There is no automated rotation hook in this server — secrets are expected to live in the MCP client configuration. For Docker deployments, wire the key through a secret manager (AWS Secrets Manager, 1Password, etc.) and inject via `-e` at runtime.
+
+---
+
+## Scopes and permissions
+
+Today there is one key type with full access to any organization the user belongs to; fine-grained scopes are planned but not shipped. Role-based access (`admin`, `editor`, `viewer`) is enforced **per organization membership**, not per key — a `viewer` membership cannot invoke write-tagged tools like `update_scoped_control` or `revalidate_evidence_file` regardless of which key they use. A `403 Access denied` response usually means the authenticated user lacks the required role in the target org.
+
+---
+
+## Security properties
+
+- **Never logged.** `SCF_API_KEY` is never printed to stderr, never included in error messages, never appears in `--debug` output.
+- **Server-side hashing.** Keys are stored as SHA-256 hashes; the platform operator cannot retrieve your plaintext key.
+- **HTTPS only.** The platform rejects plain HTTP. The client does not support custom CAs.
+- **Short-lived mutations.** Pre-signed download URLs returned by `get_evidence_file` expire after 15 minutes.
+- **npm provenance.** Every published version is cryptographically linked to its source commit via [npm provenance attestations](https://docs.npmjs.com/generating-provenance-statements) issued through GitHub Actions OIDC — no long-lived npm tokens anywhere in the release pipeline.

--- a/docs/tools/capabilities.md
+++ b/docs/tools/capabilities.md
@@ -1,0 +1,122 @@
+# Capabilities & Systems tools
+
+KSI-aligned capability themes (11 NIST 800-53-derived security capability areas) with multi-axis scorecards, evidence posture, and system inventory for mapping capabilities to the tools that implement them.
+
+Source: [`src/tools/capabilities.ts`](../../src/tools/capabilities.ts).
+
+---
+
+## `list_capability_themes`
+
+List the 11 KSI-aligned capability themes for an organization. Capability themes group NIST 800-53 controls into security capability areas, providing a high-level view of security posture.
+
+| Parameter | Type   | Required | Description                                            |
+| --------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`  | string | Yes      | Organization ID (UUID) — get from `list_organizations` |
+
+---
+
+## `get_capability_theme_scorecard`
+
+Multi-axis KSI scorecard for all capability themes in one call. Returns per-theme Implementation Coverage, Maturity, Evidence Coverage, Evidence Quality, and composite KSI Posture Score (KPS) with `Strong`/`Moderate`/`Developing` bands. Replaces the dual-call pattern of `list_capability_themes` + `get_capability_theme_evidence_posture`.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `get_capability_theme`
+
+Get a single capability theme (KSI) with full posture, multi-axis scores, bands, and legacy `posture_percentage`.
+
+| Parameter    | Type   | Required | Description                                                                        |
+| ------------ | ------ | -------- | ---------------------------------------------------------------------------------- |
+| `org_id`     | string | Yes      | Organization ID (UUID)                                                             |
+| `theme_code` | string | Yes      | Capability theme code (e.g., `ACCESS_CONTROL`) — get from `list_capability_themes` |
+
+---
+
+## `list_capability_theme_controls`
+
+List SCF controls mapped to a capability theme (KSI) with scoping status, implementation status, and maturity level. Useful for drilling from a KSI into its underlying controls.
+
+| Parameter      | Type   | Required | Description                                    |
+| -------------- | ------ | -------- | ---------------------------------------------- |
+| `org_id`       | string | Yes      | Organization ID (UUID)                         |
+| `theme_code`   | string | Yes      | Capability theme code (e.g., `ACCESS_CONTROL`) |
+| `scope_status` | string | No       | `in_scope` (default), `out_of_scope`, `all`    |
+| `limit`        | number | No       | Max results per page (1–200, default 50)       |
+| `offset`       | number | No       | Pagination offset (default 0)                  |
+
+---
+
+## `get_capability_theme_evidence_posture`
+
+Per-theme evidence assessment metrics — controls with evidence, file counts by assessment status (`sufficient`/`partial`/`insufficient`/`pending`/`unassessed`), average relevance score, and derived evidence confidence level (`strong`/`moderate`/`weak`/`none`). Useful for KSI-centric evidence quality dashboards.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `list_capabilities`
+
+List capabilities for an organization. Capabilities map to systems and evidence, showing what security functions your infrastructure supports.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `list_systems`
+
+List infrastructure systems in the organization's inventory. Systems are the tools and platforms that implement security capabilities.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `create_system`
+
+Add a system to the organization's infrastructure inventory. Systems can be linked to capabilities and evidence.
+
+| Parameter     | Type   | Required | Description                                                                                                                        |
+| ------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)                                                                                                             |
+| `name`        | string | Yes      | System name                                                                                                                        |
+| `system_type` | string | Yes      | `cloud_provider`, `identity_provider`, `ticketing`, `logging`, `security_tool`, `code_repository`, `document_management`, `custom` |
+| `description` | string | No       | System description                                                                                                                 |
+| `status`      | string | No       | `active` (default), `inactive`, `deprecated`                                                                                       |
+| `vendor`      | string | No       | Vendor ID — get from `list_vendors`                                                                                                |
+| `category`    | string | No       | System category (e.g., `SIEM`, `Endpoint`, `Identity`)                                                                             |
+
+---
+
+## `update_system`
+
+Update an existing system record. All fields are optional — only provided fields are updated.
+
+| Parameter     | Type   | Required | Description                         |
+| ------------- | ------ | -------- | ----------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)              |
+| `system_id`   | string | Yes      | System ID — get from `list_systems` |
+| `name`        | string | No       | System name                         |
+| `description` | string | No       | System description                  |
+| `system_type` | string | No       | Same enum as `create_system`        |
+| `status`      | string | No       | `active`, `inactive`, `deprecated`  |
+| `vendor`      | string | No       | Vendor ID                           |
+| `category`    | string | No       | System category                     |
+
+---
+
+## Example prompts
+
+- "Give me the KSI scorecard for my org."
+- "What's our evidence posture on `ACCESS_CONTROL`?"
+- "List all systems in our infrastructure inventory."
+- "Add Okta as an identity provider."

--- a/docs/tools/catalog.md
+++ b/docs/tools/catalog.md
@@ -1,0 +1,79 @@
+# Catalog tools
+
+Read-only access to the full SCF reference catalog — 1,451 controls, 354+ compliance frameworks, 272 evidence types, and 5,736 assessment objectives. These tools are keyless at the org level: they return the universal SCF taxonomy, not per-organization state.
+
+Source: [`src/tools/catalog.ts`](../../src/tools/catalog.ts).
+
+---
+
+## `list_controls`
+
+List SCF security controls from the reference catalog. Returns paginated controls with SCF ID, title, description, and mapped frameworks. Use domain or search filters to narrow results.
+
+| Parameter   | Type   | Required | Description                                                        |
+| ----------- | ------ | -------- | ------------------------------------------------------------------ |
+| `search`    | string | No       | Search term to filter controls by title or description             |
+| `domain`    | string | No       | Filter by compliance domain identifier (e.g., `GOV`, `AST`, `IAC`) |
+| `framework` | string | No       | Filter by framework (e.g., `nist-800-53`, `iso-27001`)             |
+| `limit`     | number | No       | Number of results to return (1–100, default 25)                    |
+| `offset`    | number | No       | Number of results to skip for pagination (default 0)               |
+
+---
+
+## `get_control`
+
+Get detailed information about a specific SCF control by its ID. Returns the control description, mapped frameworks, assessment objectives, and linked evidence items from the reference catalog.
+
+| Parameter | Type   | Required | Description                                           |
+| --------- | ------ | -------- | ----------------------------------------------------- |
+| `scf_id`  | string | Yes      | The SCF control identifier (e.g., `AST-01`, `IAC-15`) |
+
+---
+
+## `list_frameworks`
+
+List all compliance frameworks mapped in the SCF catalog. Returns framework identifiers and names. Includes NIST 800-53, ISO 27001, SOC 2, FedRAMP, GDPR, and 350+ other frameworks.
+
+_No parameters._
+
+---
+
+## `list_domains`
+
+List all compliance domains in the SCF taxonomy. Domains group related security controls (e.g., `GOV` = Governance, `AST` = Asset Management, `IAC` = Identity & Access Control).
+
+_No parameters._
+
+---
+
+## `list_evidence_catalog`
+
+List evidence items from the SCF reference catalog — the 272 standard evidence types that can be collected to demonstrate control implementation.
+
+| Parameter | Type   | Required | Description                                                  |
+| --------- | ------ | -------- | ------------------------------------------------------------ |
+| `search`  | string | No       | Search term to filter evidence items by title or description |
+| `limit`   | number | No       | Number of results to return (1–100, default 25)              |
+| `offset`  | number | No       | Number of results to skip for pagination (default 0)         |
+
+---
+
+## `list_assessment_objectives`
+
+List assessment objectives from the SCF reference catalog — the 5,736 specific test criteria used to evaluate control implementation. Filter by SCF control ID to get objectives for a specific control.
+
+| Parameter    | Type   | Required | Description                                          |
+| ------------ | ------ | -------- | ---------------------------------------------------- |
+| `control_id` | string | No       | Filter by SCF control ID (e.g., `GOV-01`, `AST-02`)  |
+| `search`     | string | No       | Search term to filter assessment objectives          |
+| `limit`      | number | No       | Number of results to return (1–100, default 25)      |
+| `offset`     | number | No       | Number of results to skip for pagination (default 0) |
+
+---
+
+## Example prompts
+
+- "What NIST 800-53 controls apply to access control?"
+- "Show me the assessment objectives for `GOV-01`."
+- "List all frameworks mapped in SCF."
+- "Find every control in the `IAC` domain."

--- a/docs/tools/evidence.md
+++ b/docs/tools/evidence.md
@@ -1,0 +1,254 @@
+# Evidence tools
+
+Track evidence artifacts that demonstrate control implementation, run AI-powered assessments of uploaded files, validate against catalog rules, and score portfolio-level coverage with windowed assessments.
+
+Source: [`src/tools/evidence.ts`](../../src/tools/evidence.ts).
+
+The 19 tools in this domain split into five concerns:
+
+1. **CRUD** — `list_evidence`, `create_evidence`, `update_evidence`, `get_evidence_maturity`, `list_evidence_tasks`
+2. **Files** — `list_evidence_files`, `get_evidence_file`
+3. **Validation** — `get_evidence_validation`, `revalidate_evidence_file`, `get_evidence_validation_summary`
+4. **Per-file AI assessment** — `trigger_evidence_assessment`, `get_evidence_assessment`, `bulk_assess_evidence`, `get_evidence_assessment_summary`
+5. **Windowed AI assessment** — `trigger_window_assessment`, `list_window_assessments`, `get_window_assessment`, `bulk_assess_windows`, `get_window_assessment_summary`
+
+---
+
+## `list_evidence`
+
+List evidence items tracked for an organization's controls. Evidence demonstrates control implementation for audit readiness. Returns evidence with status, maturity, and linked controls.
+
+| Parameter   | Type   | Required | Description                                            |
+| ----------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`    | string | Yes      | Organization ID (UUID) — get from `list_organizations` |
+| `system_id` | string | No       | Filter by system ID                                    |
+
+---
+
+## `create_evidence`
+
+Create an evidence tracking record from the SCF evidence catalog. Uses a catalog evidence ID (e.g., `E-IAM-01`) to start tracking an evidence item.
+
+| Parameter              | Type    | Required | Description                                                               |
+| ---------------------- | ------- | -------- | ------------------------------------------------------------------------- |
+| `org_id`               | string  | Yes      | Organization ID (UUID)                                                    |
+| `evidence_id`          | string  | Yes      | Catalog evidence ID (e.g., `E-IAM-01`) — get from `list_evidence_catalog` |
+| `is_tracked`           | boolean | No       | Whether this evidence item is actively tracked (default `false`)          |
+| `system_id`            | string  | No       | System ID (UUID) to link this evidence to — get from `list_systems`       |
+| `method_of_collection` | string  | No       | How evidence is collected (`automated`, `manual`, `hybrid`)               |
+| `collecting_system`    | string  | No       | System or tool used to collect the evidence                               |
+| `owner`                | string  | No       | Person responsible for this evidence item                                 |
+| `frequency`            | string  | No       | `daily`, `weekly`, `monthly`, `quarterly`, `annually`                     |
+| `comments`             | string  | No       | Additional notes or context                                               |
+
+---
+
+## `update_evidence`
+
+Update an evidence item's tracking fields — toggle tracking, link to a system, set collection method, owner, frequency, etc. Identify by catalog evidence ID. All fields except `org_id`/`evidence_id` are optional. Uses POST-upsert semantics (creates the tracking row if it doesn't exist).
+
+| Parameter              | Type    | Required | Description                                           |
+| ---------------------- | ------- | -------- | ----------------------------------------------------- |
+| `org_id`               | string  | Yes      | Organization ID (UUID)                                |
+| `evidence_id`          | string  | Yes      | Catalog evidence ID (e.g., `E-IAM-01`)                |
+| `is_tracked`           | boolean | No       | Whether this evidence item is actively tracked        |
+| `system_id`            | string  | No       | System ID (UUID) to link this evidence to             |
+| `method_of_collection` | string  | No       | `automated`, `manual`, `hybrid`                       |
+| `collecting_system`    | string  | No       | System or tool used to collect the evidence           |
+| `owner`                | string  | No       | Person responsible for this evidence item             |
+| `frequency`            | string  | No       | `daily`, `weekly`, `monthly`, `quarterly`, `annually` |
+| `comments`             | string  | No       | Additional notes or context                           |
+
+---
+
+## `get_evidence_maturity`
+
+Get evidence maturity summary — average maturity score, automation percentage, distribution by maturity level, and improvement opportunities.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `list_evidence_tasks`
+
+List evidence collection tasks — the work queue for gathering evidence. Shows what needs to be collected, by whom, and by when.
+
+| Parameter  | Type   | Required | Description             |
+| ---------- | ------ | -------- | ----------------------- |
+| `org_id`   | string | No       | Organization ID (UUID)  |
+| `assignee` | string | No       | Filter by assigned user |
+| `status`   | string | No       | Filter by task status   |
+
+---
+
+## `list_evidence_files`
+
+List all files uploaded or ingested for a specific evidence item. Returns file metadata including filename, content type, upload timestamp, validation status, and a pre-signed download URL (15-minute expiry).
+
+| Parameter     | Type   | Required | Description                       |
+| ------------- | ------ | -------- | --------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)            |
+| `evidence_id` | string | Yes      | Evidence ID (e.g., `ERL-IAM-001`) |
+
+---
+
+## `get_evidence_file`
+
+Get metadata and a pre-signed download URL for a single evidence file. Download URL expires after 15 minutes.
+
+| Parameter     | Type   | Required | Description                                              |
+| ------------- | ------ | -------- | -------------------------------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)                                   |
+| `evidence_id` | string | Yes      | Evidence ID                                              |
+| `file_id`     | string | Yes      | Evidence file ID (UUID) — get from `list_evidence_files` |
+
+---
+
+## `get_evidence_validation`
+
+Get the validation result for a specific evidence file. Returns overall status (`valid`/`warning`/`partial`/`invalid`), completeness score, individual rule findings (`catalog_exists`, `content_type_ok`, `field_coverage`, `freshness`, `s3_object_exists`), validation source, and timestamp.
+
+| Parameter     | Type   | Required | Description             |
+| ------------- | ------ | -------- | ----------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)  |
+| `evidence_id` | string | Yes      | Evidence ID             |
+| `file_id`     | string | Yes      | Evidence file ID (UUID) |
+
+---
+
+## `revalidate_evidence_file`
+
+Re-run the validation engine against a specific evidence file. Checks catalog existence, content type, field coverage, freshness, and storage object existence. Upserts the validation result and returns it. **Requires editor role or higher.**
+
+| Parameter     | Type   | Required | Description             |
+| ------------- | ------ | -------- | ----------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)  |
+| `evidence_id` | string | Yes      | Evidence ID             |
+| `file_id`     | string | Yes      | Evidence file ID (UUID) |
+
+---
+
+## `get_evidence_validation_summary`
+
+Get aggregate evidence validation metrics for the organization dashboard. Returns total files validated, counts by status (`valid`, `warning`, `partial`, `invalid`), and overall pass rate.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `trigger_evidence_assessment`
+
+Trigger an AI-powered assessment of an evidence artifact file. Evaluates relevance, completeness, and quality against mapped SCF controls. Returns a pending assessment record — poll `get_evidence_assessment` until status changes. **Requires editor role or higher.**
+
+| Parameter           | Type   | Required | Description                           |
+| ------------------- | ------ | -------- | ------------------------------------- |
+| `org_id`            | string | Yes      | Organization ID (UUID)                |
+| `evidence_id`       | string | Yes      | Evidence ID                           |
+| `file_id`           | string | Yes      | Evidence file ID (UUID)               |
+| `assessment_source` | string | No       | `on_demand` (default), `auto`, `bulk` |
+
+---
+
+## `get_evidence_assessment`
+
+Get the AI assessment result for an evidence file. Returns status (`pending`/`processing`/`sufficient`/`partial`/`insufficient`/`error`), relevance score (0–100), structured findings, summary text, and full audit metadata (model, token counts, cost).
+
+| Parameter     | Type   | Required | Description             |
+| ------------- | ------ | -------- | ----------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)  |
+| `evidence_id` | string | Yes      | Evidence ID             |
+| `file_id`     | string | Yes      | Evidence file ID (UUID) |
+
+---
+
+## `bulk_assess_evidence`
+
+Queue AI assessments for multiple evidence files at once (max 50 per request). Provide at least one of: `evidence_id`, `file_ids`, or `assess_unassessed`. **Requires editor role or higher.**
+
+| Parameter           | Type    | Required | Description                                     |
+| ------------------- | ------- | -------- | ----------------------------------------------- |
+| `org_id`            | string  | Yes      | Organization ID (UUID)                          |
+| `evidence_id`       | string  | No       | Assess all files for this evidence item         |
+| `file_ids`          | array   | No       | Specific evidence file IDs (UUIDs) to assess    |
+| `assess_unassessed` | boolean | No       | Assess all files without an existing assessment |
+
+---
+
+## `get_evidence_assessment_summary`
+
+Get aggregate AI assessment metrics — total assessed count, counts by status, unassessed count, average relevance score, and total cost in cents.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `trigger_window_assessment`
+
+Queue a windowed AI assessment for an evidence item. Scores all files uploaded inside the frequency-derived window as a portfolio against the union of required artifact types across mapped SCF controls. Returns 202 — poll with `list_window_assessments` or `get_window_assessment`. **Requires editor role or higher.** Returns 422 if the evidence has no tracking row or no frequency set (set one via `update_evidence`).
+
+| Parameter           | Type   | Required | Description                                           |
+| ------------------- | ------ | -------- | ----------------------------------------------------- |
+| `org_id`            | string | Yes      | Organization ID (UUID)                                |
+| `evidence_id`       | string | Yes      | Evidence ID — must have tracking with a frequency set |
+| `assessment_source` | string | No       | `on_demand` (default), `auto`, `bulk`                 |
+
+---
+
+## `list_window_assessments`
+
+List the most recent windowed AI assessments for a specific evidence ID (newest first). Each entry includes window boundaries, frequency used, file IDs in the window, source/artifact coverage, status, relevance score, findings, and cost.
+
+| Parameter     | Type   | Required | Description                   |
+| ------------- | ------ | -------- | ----------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)        |
+| `evidence_id` | string | Yes      | Evidence ID                   |
+| `limit`       | number | No       | 1–100, default 10             |
+| `offset`      | number | No       | Pagination offset (default 0) |
+
+---
+
+## `get_window_assessment`
+
+Get a single windowed AI assessment by its assessment ID. Returns full detail: window boundaries, frequency, file IDs, coverage metrics, status, relevance score, findings, summary, hashes, token counts, cost, and timing.
+
+| Parameter       | Type   | Required | Description                                                        |
+| --------------- | ------ | -------- | ------------------------------------------------------------------ |
+| `org_id`        | string | Yes      | Organization ID (UUID)                                             |
+| `assessment_id` | string | Yes      | Windowed assessment ID (UUID) — get from `list_window_assessments` |
+
+---
+
+## `bulk_assess_windows`
+
+Queue windowed AI assessments for multiple evidence IDs in one call (max 25 per request). Evidence items without a tracking row or frequency are skipped and reported under `skipped_detail`. **Requires editor role or higher.**
+
+| Parameter      | Type   | Required | Description                                         |
+| -------------- | ------ | -------- | --------------------------------------------------- |
+| `org_id`       | string | Yes      | Organization ID (UUID)                              |
+| `evidence_ids` | array  | Yes      | 1–25 evidence IDs (e.g., `['E-IAM-01','E-BCM-11']`) |
+
+---
+
+## `get_window_assessment_summary`
+
+Aggregate windowed-assessment metrics — total windows assessed, counts by status (`sufficient`/`partial`/`insufficient`/`insufficient_sample`/`pending`/`error`), average relevance score, and total cost in cents. `insufficient_sample` indicates the content was fine but the window had too few files to cover the controls' required artifact types.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## Example prompts
+
+- "What evidence do I need to collect for SOC 2 audit?"
+- "Run AI assessment on the latest file uploaded to `E-IAM-01`."
+- "Give me this month's evidence validation pass rate."
+- "Trigger windowed assessments for all my `daily`-frequency evidence items."
+- "Show evidence maturity by control domain."

--- a/docs/tools/organization.md
+++ b/docs/tools/organization.md
@@ -1,0 +1,81 @@
+# Organization & Platform tools
+
+Current user profile, organization management, membership lookups, personal work queue, field-level audit trail, and notification feed.
+
+Source: [`src/tools/organization.ts`](../../src/tools/organization.ts).
+
+---
+
+## `get_current_user`
+
+Get the current authenticated user's profile, including name, email, organizations, and role.
+
+_No parameters._
+
+---
+
+## `list_organizations`
+
+List organizations the current user has access to. Returns org ID, name, tier, and member count.
+
+_No parameters._
+
+---
+
+## `get_organization`
+
+Get detailed organization information including subscription tier, member count, usage limits, and settings.
+
+| Parameter | Type   | Required | Description                                            |
+| --------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`  | string | Yes      | Organization ID (UUID) — get from `list_organizations` |
+
+---
+
+## `list_members`
+
+List members of an organization with their roles (`admin`, `editor`, `viewer`).
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `get_work_queue`
+
+Get the authenticated user's work queue — a prioritized list of pending tasks, assignments, and action items across all their organizations.
+
+_No parameters._
+
+---
+
+## `get_audit_log`
+
+Get the audit trail for an organization. Field-level changes to controls, evidence, and other entities with actor, timestamp, and before/after values.
+
+| Parameter | Type   | Required | Description                                |
+| --------- | ------ | -------- | ------------------------------------------ |
+| `org_id`  | string | Yes      | Organization ID (UUID)                     |
+| `limit`   | number | No       | Results to return (1–100, default 50)      |
+| `offset`  | number | No       | Results to skip for pagination (default 0) |
+
+---
+
+## `get_notifications`
+
+Get notifications for the current user — new assignments, comments, status changes, and system alerts.
+
+| Parameter     | Type    | Required | Description                                        |
+| ------------- | ------- | -------- | -------------------------------------------------- |
+| `unread_only` | boolean | No       | Only return unread notifications (default `false`) |
+| `limit`       | number  | No       | Notifications to return (1–100, default 25)        |
+
+---
+
+## Example prompts
+
+- "What's in my compliance work queue today?"
+- "Show me who changed `AST-01` last week."
+- "List the organizations I belong to."
+- "Are there any unread notifications?"

--- a/docs/tools/risk.md
+++ b/docs/tools/risk.md
@@ -1,0 +1,166 @@
+# Risk Management tools
+
+5x5 risk matrix with inherent and residual scoring, treatment tracking, severity summaries, and org-defined custom risks with control mappings. Custom risks auto-generate `R-ORG-N` codes alongside the static SCF risk catalog.
+
+Source: [`src/tools/risk.ts`](../../src/tools/risk.ts).
+
+The 12 tools split into three concerns:
+
+1. **Risk register** — `list_risks`, `get_risk`, `create_risk`, `get_risk_matrix`, `get_risk_summary`
+2. **Custom risk definitions** — `list_custom_risks`, `create_custom_risk`, `update_custom_risk`, `delete_custom_risk`
+3. **Custom risk control mappings** — `list_custom_risk_controls`, `add_custom_risk_control`, `remove_custom_risk_control`
+
+---
+
+## `list_risks`
+
+List risk assessments in the organization's risk register. Returns risks with likelihood, impact, treatment status, and linked controls.
+
+| Parameter  | Type   | Required | Description                                            |
+| ---------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`   | string | Yes      | Organization ID (UUID) — get from `list_organizations` |
+| `status`   | string | No       | Filter by treatment status                             |
+| `page`     | number | No       | Page number (default 1)                                |
+| `per_page` | number | No       | Results per page (1–100, default 25)                   |
+
+---
+
+## `get_risk`
+
+Get detailed risk assessment including likelihood/impact scores (inherent and residual), treatment plan, owner, and review date.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+| `risk_id` | string | Yes      | Risk assessment ID     |
+
+---
+
+## `create_risk`
+
+Create a new risk assessment in the risk register. Requires likelihood and impact scores for the 5x5 matrix.
+
+| Parameter          | Type   | Required | Description                               |
+| ------------------ | ------ | -------- | ----------------------------------------- |
+| `org_id`           | string | Yes      | Organization ID (UUID)                    |
+| `title`            | string | Yes      | Risk title                                |
+| `description`      | string | Yes      | Risk description                          |
+| `likelihood`       | number | Yes      | Inherent likelihood (1–5)                 |
+| `impact`           | number | Yes      | Inherent impact (1–5)                     |
+| `owner`            | string | No       | Risk owner                                |
+| `treatment_status` | string | No       | `mitigate`, `accept`, `transfer`, `avoid` |
+| `control_id`       | string | No       | Linked control ID                         |
+
+---
+
+## `get_risk_matrix`
+
+Get the 5x5 risk matrix visualization data. Shows risk distribution across likelihood and impact dimensions.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `get_risk_summary`
+
+Aggregated risk summary — total risks by severity, treatment status breakdown, and trend data.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `list_custom_risks`
+
+List custom (organization-defined) risk definitions. These are risks created by the org alongside the static SCF risk catalog, with auto-generated `R-ORG-N` codes.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `create_custom_risk`
+
+Create a custom organization-defined risk. Auto-generates an `R-ORG-N` code and creates the corresponding risk assessment record.
+
+| Parameter        | Type   | Required | Description                                       |
+| ---------------- | ------ | -------- | ------------------------------------------------- |
+| `org_id`         | string | Yes      | Organization ID (UUID)                            |
+| `title`          | string | Yes      | Risk title (max 100 chars)                        |
+| `description`    | string | Yes      | Risk description                                  |
+| `category_name`  | string | No       | Category label (default `Custom`)                 |
+| `category_color` | string | No       | Hex colour for category badge (default `#6b7280`) |
+
+---
+
+## `update_custom_risk`
+
+Update a custom risk definition's metadata (title, description, category).
+
+| Parameter        | Type   | Required | Description                        |
+| ---------------- | ------ | -------- | ---------------------------------- |
+| `org_id`         | string | Yes      | Organization ID (UUID)             |
+| `risk_code`      | string | Yes      | Custom risk code (e.g., `R-ORG-1`) |
+| `title`          | string | No       | Updated risk title                 |
+| `description`    | string | No       | Updated risk description           |
+| `category_name`  | string | No       | Updated category label             |
+| `category_color` | string | No       | Updated hex colour                 |
+
+---
+
+## `delete_custom_risk`
+
+Delete a custom risk definition and its assessment record. Also removes any control mappings.
+
+| Parameter   | Type   | Required | Description                        |
+| ----------- | ------ | -------- | ---------------------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID)             |
+| `risk_code` | string | Yes      | Custom risk code (e.g., `R-ORG-1`) |
+
+---
+
+## `list_custom_risk_controls`
+
+List controls manually linked to a custom risk. Returns the same shape as controls-for-risk (`catalog_control_ids` + `scoped_controls` with implementation status).
+
+| Parameter   | Type   | Required | Description                        |
+| ----------- | ------ | -------- | ---------------------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID)             |
+| `risk_code` | string | Yes      | Custom risk code (e.g., `R-ORG-1`) |
+
+---
+
+## `add_custom_risk_control`
+
+Link a scoped control to a custom risk. The control must be scoped (selected) for this organization.
+
+| Parameter   | Type   | Required | Description                             |
+| ----------- | ------ | -------- | --------------------------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID)                  |
+| `risk_code` | string | Yes      | Custom risk code (e.g., `R-ORG-1`)      |
+| `scf_id`    | string | Yes      | SCF control ID to link (e.g., `AST-01`) |
+
+---
+
+## `remove_custom_risk_control`
+
+Remove a control link from a custom risk.
+
+| Parameter   | Type   | Required | Description                               |
+| ----------- | ------ | -------- | ----------------------------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID)                    |
+| `risk_code` | string | Yes      | Custom risk code (e.g., `R-ORG-1`)        |
+| `scf_id`    | string | Yes      | SCF control ID to unlink (e.g., `AST-01`) |
+
+---
+
+## Example prompts
+
+- "Show the 5x5 risk matrix for my organization."
+- "Create a risk assessment for our cloud migration."
+- "List all critical risks needing treatment."
+- "Define a custom risk for supplier concentration and link `GOV-12`."

--- a/docs/tools/scoped-controls.md
+++ b/docs/tools/scoped-controls.md
@@ -1,0 +1,111 @@
+# Control Scoping tools
+
+Track implementation status of SCF controls scoped to a specific organization. Supports an 8-state implementation workflow (`not_started`, `in_progress`, `implemented`, `ready_for_review`, `monitored`, `not_applicable`, `at_risk`, `deferred`) and a 6-level maturity scale (`L0`–`L5`).
+
+Source: [`src/tools/scoped-controls.ts`](../../src/tools/scoped-controls.ts).
+
+---
+
+## `list_scoped_controls`
+
+List controls scoped to your organization with their implementation status. Supports filtering by scope status, domain, framework, CSF function, control weighting, and search. Use `scope_status='in_scope'` to return only controls where `selected=True`.
+
+| Parameter           | Type   | Required | Description                                                 |
+| ------------------- | ------ | -------- | ----------------------------------------------------------- |
+| `org_id`            | string | Yes      | Organization ID (UUID) — get from `list_organizations`      |
+| `scope_status`      | string | No       | `in_scope` (selected only), `out_of_scope`, `all` (default) |
+| `domain`            | string | No       | Filter by SCF domain (e.g., `GOV`, `AST`, `IAC`)            |
+| `framework`         | string | No       | Filter by framework mapping                                 |
+| `csf_function`      | string | No       | Filter by NIST CSF function                                 |
+| `control_weighting` | number | No       | Filter by control weighting (0–10)                          |
+| `search`            | string | No       | Search term for control ID, name, or description            |
+| `limit`             | number | No       | Number of results to return (1–200, default 50)             |
+| `offset`            | number | No       | Number of results to skip for pagination (default 0)        |
+
+---
+
+## `get_scoped_control`
+
+Get detailed implementation status of a specific scoped control, including owner, notes, evidence links, and audit history. Identify by `scf_id` (e.g., `AST-01`), not by UUID.
+
+| Parameter | Type   | Required | Description                                            |
+| --------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`  | string | Yes      | Organization ID (UUID) — get from `list_organizations` |
+| `scf_id`  | string | Yes      | SCF control identifier (e.g., `AST-01`) — NOT the UUID |
+
+---
+
+## `update_scoped_control`
+
+Update a scoped control's implementation tracking fields. Status values are lowercase. Maturity uses the `L0`–`L5` prefix format. All fields are optional — only provided fields are updated.
+
+| Parameter               | Type   | Required | Description                                                                                                                      |
+| ----------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `org_id`                | string | Yes      | Organization ID (UUID)                                                                                                           |
+| `scf_id`                | string | Yes      | SCF control identifier (e.g., `AST-01`) — NOT the UUID                                                                           |
+| `implementation_status` | string | No       | One of: `not_started`, `in_progress`, `implemented`, `ready_for_review`, `monitored`, `not_applicable`, `at_risk`, `deferred`    |
+| `priority`              | string | No       | Implementation priority (e.g., `high`, `medium`, `low`)                                                                          |
+| `maturity_level`        | string | No       | `L0`=Not Performed, `L1`=Performed, `L2`=Planned, `L3`=Well Defined, `L4`=Quantitatively Controlled, `L5`=Continuously Improving |
+| `owner`                 | string | No       | Control owner (person accountable)                                                                                               |
+| `assigned_to`           | string | No       | Assignee (person responsible for implementation)                                                                                 |
+| `implementation_notes`  | string | No       | Implementation notes and context                                                                                                 |
+| `target_date`           | string | No       | Target completion date (`YYYY-MM-DD`)                                                                                            |
+| `completion_date`       | string | No       | Actual completion date (`YYYY-MM-DD`)                                                                                            |
+| `selection_reason`      | string | No       | Justification for scoping selection or status (required for `not_applicable`, `deferred`)                                        |
+
+---
+
+## `get_scoping_stats`
+
+Get implementation statistics for an organization — counts by status, completion percentage, and framework coverage breakdown.
+
+| Parameter | Type   | Required | Description                                            |
+| --------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`  | string | Yes      | Organization ID (UUID) — get from `list_organizations` |
+
+---
+
+## `scope_framework`
+
+Bulk-scope every control from a framework into your organization. Creates scoped-control entries for all controls in the framework.
+
+| Parameter      | Type   | Required | Description                                    |
+| -------------- | ------ | -------- | ---------------------------------------------- |
+| `org_id`       | string | Yes      | Organization ID (UUID)                         |
+| `framework_id` | string | Yes      | Framework ID to scope (e.g., `nist-800-53-r5`) |
+
+---
+
+## `batch_update_controls`
+
+Batch update multiple scoped controls in a single transaction. Maximum 500 operations per request. Status values must be lowercase; maturity uses the `L` prefix format.
+
+| Parameter    | Type   | Required | Description                                       |
+| ------------ | ------ | -------- | ------------------------------------------------- |
+| `org_id`     | string | Yes      | Organization ID (UUID)                            |
+| `operations` | array  | Yes      | 1–500 operations (see per-operation fields below) |
+
+Each operation accepts:
+
+| Field                   | Type    | Required | Description                             |
+| ----------------------- | ------- | -------- | --------------------------------------- |
+| `scf_id`                | string  | Yes      | SCF control identifier (e.g., `AST-01`) |
+| `selected`              | boolean | No       | Whether the control is in scope         |
+| `implementation_status` | string  | No       | Implementation status (lowercase)       |
+| `selection_reason`      | string  | No       | Justification for selection or status   |
+| `priority`              | string  | No       | Implementation priority                 |
+| `owner`                 | string  | No       | Control owner                           |
+| `assigned_to`           | string  | No       | Assignee                                |
+| `maturity_level`        | string  | No       | Maturity level (`L0`–`L5`)              |
+| `target_date`           | string  | No       | Target date (`YYYY-MM-DD`)              |
+| `completion_date`       | string  | No       | Completion date (`YYYY-MM-DD`)          |
+| `implementation_notes`  | string  | No       | Implementation notes                    |
+
+---
+
+## Example prompts
+
+- "Show me our organization's control implementation progress."
+- "Scope the ISO 27001 framework for my org."
+- "Batch update all access-control controls to `in_progress`."
+- "Get the implementation status of `AST-01`."

--- a/docs/tools/vendors.md
+++ b/docs/tools/vendors.md
@@ -1,0 +1,113 @@
+# Vendor Risk (TPRM) tools
+
+Third-party risk management with AI-powered security research (HIBP/NVD lookups, breach history, vulnerability scanning) and Data Protection Security Impact Assessments (DPSIA).
+
+Source: [`src/tools/vendors.ts`](../../src/tools/vendors.ts).
+
+---
+
+## `list_vendors`
+
+List third-party vendors in the organization's TPRM registry. Filter by status, criticality, or category.
+
+| Parameter     | Type   | Required | Description                                      |
+| ------------- | ------ | -------- | ------------------------------------------------ |
+| `org_id`      | string | Yes      | Organization ID (UUID)                           |
+| `status`      | string | No       | `prospect`, `active`, `inactive`, `under_review` |
+| `criticality` | string | No       | `critical`, `high`, `medium`, `low`              |
+| `page`        | number | No       | Page number (default 1)                          |
+| `per_page`    | number | No       | Results per page (1–100, default 25)             |
+
+---
+
+## `get_vendor`
+
+Get detailed vendor information including certifications, assessments, risk score, and research results.
+
+| Parameter   | Type   | Required | Description            |
+| ----------- | ------ | -------- | ---------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID) |
+| `vendor_id` | string | Yes      | Vendor ID              |
+
+---
+
+## `create_vendor`
+
+Add a new vendor to the TPRM registry. Triggers automatic risk scoring based on criticality and data handling.
+
+| Parameter       | Type   | Required | Description                                                |
+| --------------- | ------ | -------- | ---------------------------------------------------------- |
+| `org_id`        | string | Yes      | Organization ID (UUID)                                     |
+| `name`          | string | Yes      | Vendor name                                                |
+| `description`   | string | No       | Vendor description                                         |
+| `category`      | string | No       | Category (e.g., `SaaS`, `Infrastructure`, `Consulting`)    |
+| `criticality`   | string | No       | `critical`, `high`, `medium` (default), `low`              |
+| `status`        | string | No       | `prospect` (default), `active`, `inactive`, `under_review` |
+| `website`       | string | No       | Vendor website URL                                         |
+| `contact_email` | string | No       | Primary contact email                                      |
+
+---
+
+## `update_vendor`
+
+Update an existing vendor record. All fields are optional — only provided fields are updated.
+
+| Parameter       | Type   | Required | Description                                      |
+| --------------- | ------ | -------- | ------------------------------------------------ |
+| `org_id`        | string | Yes      | Organization ID (UUID)                           |
+| `vendor_id`     | string | Yes      | Vendor ID — get from `list_vendors`              |
+| `name`          | string | No       | Vendor name                                      |
+| `description`   | string | No       | Vendor description                               |
+| `category`      | string | No       | Category                                         |
+| `criticality`   | string | No       | `critical`, `high`, `medium`, `low`              |
+| `status`        | string | No       | `prospect`, `active`, `inactive`, `under_review` |
+| `website`       | string | No       | Vendor website URL                               |
+| `contact_email` | string | No       | Primary contact email                            |
+
+---
+
+## `trigger_vendor_research`
+
+Trigger AI-powered security research for a vendor. Checks HIBP (breach databases), NVD (vulnerability databases), and public security posture. Returns a task ID for status polling.
+
+| Parameter         | Type   | Required | Description                                              |
+| ----------------- | ------ | -------- | -------------------------------------------------------- |
+| `org_id`          | string | Yes      | Organization ID (UUID)                                   |
+| `vendor_id`       | string | Yes      | Vendor ID                                                |
+| `domain_override` | string | No       | Override the vendor's website domain for research lookup |
+
+---
+
+## `get_vendor_research`
+
+Get the latest AI-powered research results for a vendor — breach history, known vulnerabilities, and security posture analysis.
+
+| Parameter   | Type   | Required | Description            |
+| ----------- | ------ | -------- | ---------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID) |
+| `vendor_id` | string | Yes      | Vendor ID              |
+
+---
+
+## `trigger_dpsia`
+
+Trigger a Data Protection Security Impact Assessment (DPSIA) for a vendor. Evaluates security posture against the CIA triad and certification requirements. If `services_used` is omitted, it's auto-derived from the vendor description.
+
+| Parameter            | Type   | Required | Description                                                           |
+| -------------------- | ------ | -------- | --------------------------------------------------------------------- |
+| `org_id`             | string | Yes      | Organization ID (UUID)                                                |
+| `vendor_id`          | string | Yes      | Vendor ID                                                             |
+| `services_used`      | string | No       | Description of services the vendor provides (auto-derived if omitted) |
+| `assessment_type`    | string | No       | `new` (default), `annual-review`, `adhoc`                             |
+| `data_role`          | string | No       | `Processor` (default), `Controller`, `Joint Controller`               |
+| `client_name`        | string | No       | Client/organisation name for the assessment                           |
+| `additional_context` | string | No       | Additional context (e.g., specific concerns, scope notes)             |
+
+---
+
+## Example prompts
+
+- "List all critical vendors and their risk scores."
+- "Run a DPSIA on our cloud provider vendor."
+- "What breaches has our payment processor had?"
+- "Add Stripe as a critical vendor for payment processing."

--- a/docs/tools/webhooks.md
+++ b/docs/tools/webhooks.md
@@ -1,0 +1,92 @@
+# Webhook tools
+
+Manage HMAC-authenticated webhook endpoints for evidence inbox ingestion. External systems (SIEMs, CSPMs, ticketing tools) use these endpoints to push evidence into the platform via signed POST requests.
+
+Source: [`src/tools/webhooks.ts`](../../src/tools/webhooks.ts).
+
+The 6 tools split into three concerns:
+
+1. **Endpoint CRUD** — `create_webhook`, `list_webhooks`, `get_webhook`, `delete_webhook`
+2. **Secret rotation** — `rotate_webhook_secret`
+3. **Delivery logs** — `list_webhook_deliveries`
+
+> **Security note:** the HMAC signing secret is returned **once** on creation and rotation — it cannot be retrieved later. Store it in a secret manager before the response is discarded.
+
+---
+
+## `create_webhook`
+
+Create a new webhook endpoint for evidence inbox ingestion. External systems push evidence via HMAC-authenticated POST requests. Returns the plaintext signing secret once — it cannot be retrieved later.
+
+| Parameter               | Type   | Required | Description                                                                                         |
+| ----------------------- | ------ | -------- | --------------------------------------------------------------------------------------------------- |
+| `org_id`                | string | Yes      | Organization ID (UUID)                                                                              |
+| `name`                  | string | Yes      | Human-readable label (e.g., `Splunk SIEM`, `AWS Config`)                                            |
+| `description`           | string | No       | Optional description of the endpoint's purpose                                                      |
+| `allowed_evidence_ids`  | array  | No       | Restrict ingestion to specific evidence IDs (e.g., `['ERL-IAM-001']`). Null allows any evidence ID. |
+| `rate_limit_per_minute` | number | No       | Per-endpoint rate limit (1–10000 req/min). Null uses the organization default.                      |
+
+---
+
+## `list_webhooks`
+
+List all webhook endpoints for an organization, ordered by creation date (newest first). Shows endpoint name, status, delivery count, and secret prefix.
+
+| Parameter | Type   | Required | Description            |
+| --------- | ------ | -------- | ---------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) |
+
+---
+
+## `get_webhook`
+
+Get detailed information about a single webhook endpoint including delivery stats, allowed evidence IDs, and rate limit configuration.
+
+| Parameter     | Type   | Required | Description                                           |
+| ------------- | ------ | -------- | ----------------------------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)                                |
+| `endpoint_id` | string | Yes      | Webhook endpoint ID (UUID) — get from `list_webhooks` |
+
+---
+
+## `delete_webhook`
+
+Revoke a webhook endpoint (soft-delete). Sets the endpoint to inactive — future deliveries will be rejected with 403. The endpoint record is preserved for audit trail.
+
+| Parameter     | Type   | Required | Description                |
+| ------------- | ------ | -------- | -------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)     |
+| `endpoint_id` | string | Yes      | Webhook endpoint ID (UUID) |
+
+---
+
+## `rotate_webhook_secret`
+
+Generate a new HMAC signing secret for a webhook endpoint. The old secret is immediately invalidated. Returns the new plaintext secret once — store it securely.
+
+| Parameter     | Type   | Required | Description                |
+| ------------- | ------ | -------- | -------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)     |
+| `endpoint_id` | string | Yes      | Webhook endpoint ID (UUID) |
+
+---
+
+## `list_webhook_deliveries`
+
+List delivery logs for a webhook endpoint (newest first). Each entry shows signature validation result, processing status, evidence ID, and timestamps. Useful for debugging integration issues.
+
+| Parameter     | Type   | Required | Description                                             |
+| ------------- | ------ | -------- | ------------------------------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID)                                  |
+| `endpoint_id` | string | Yes      | Webhook endpoint ID (UUID)                              |
+| `limit`       | number | No       | Number of deliveries to return (1–200, default 50)      |
+| `offset`      | number | No       | Number of deliveries to skip for pagination (default 0) |
+
+---
+
+## Example prompts
+
+- "Create a webhook endpoint for our Splunk SIEM restricted to `ERL-IAM-001`."
+- "List all webhook endpoints and their delivery counts."
+- "Rotate the secret on our AWS Config webhook."
+- "Show me the last 20 delivery failures for endpoint X."

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,196 @@
+# Troubleshooting
+
+Common failure modes for `mcp-server-scf`, each as a **symptom → cause → fix** triplet. If nothing here matches, capture a verbose stderr log (see the last section) and open a bug report using the issue template.
+
+---
+
+## Invalid API key / 401
+
+**Symptom**
+Every tool call returns `Authentication failed. Check your SCF_API_KEY.` or the MCP client surfaces a `401 Unauthorized`.
+
+**Cause**
+One of:
+
+- The key is missing, truncated, or has a stray newline.
+- The key belongs to a different region than `SCF_API_URL` points at.
+- The key was revoked or rotated server-side.
+- The key doesn't start with `scf_` — likely a UUID copy-paste mistake.
+
+**Fix**
+
+1. Confirm the key begins with `scf_` and has no whitespace:
+   ```bash
+   echo -n "$SCF_API_KEY" | head -c 4   # should print: scf_
+   echo -n "$SCF_API_KEY" | wc -c       # should match the length shown at generation time
+   ```
+2. Verify the region matches — see [Region selection](#region-selection) below.
+3. Generate a new key in **Settings → API Keys** and update every MCP client config, then restart the client.
+4. If the key works in `curl` but not in the MCP client, the client isn't passing the `env` block through — see [Claude Desktop config](#claude-desktop-config-path-per-os).
+
+---
+
+## Region selection: EU vs US
+
+**Symptom**
+Key looks correct (starts with `scf_`, length matches) but every request returns `401`.
+
+**Cause**
+API keys are region-scoped. A key minted on `eu.scfcontrolsplatform.app` will not authenticate against `scfcontrolsplatform.com` (US) and vice versa.
+
+**Fix**
+Set `SCF_API_URL` to match the region where the key was issued:
+
+| Region | `SCF_API_URL`                                  |
+| ------ | ---------------------------------------------- |
+| EU     | `https://eu.scfcontrolsplatform.app` (default) |
+| US     | `https://scfcontrolsplatform.com`              |
+
+If you're unsure, log into the platform console — the domain in the browser tells you the region.
+
+---
+
+## Rate limits (429)
+
+**Symptom**
+After a burst of tool calls, you get `Rate limited. Please wait before retrying.`
+
+**Cause**
+The platform enforces **100 read requests/min and 20 write requests/min per API key**. The MCP server has no built-in retry/backoff.
+
+**Fix**
+
+- For bulk work, use the batch tools — `batch_update_controls` (up to 500 operations), `bulk_assess_evidence` (up to 50 files), `bulk_assess_windows` (up to 25 evidence IDs). They count as a single request.
+- If you're looping `update_scoped_control` in a script, wait 60 seconds or switch to `batch_update_controls`.
+- Persistent 429s on modest traffic suggest a second process is sharing the key — rotate and investigate.
+
+---
+
+## Claude Desktop config path per OS
+
+**Symptom**
+You edited a config file but the server doesn't appear in Claude Desktop's MCP status bar, or edits don't take effect after restart.
+
+**Cause**
+Wrong path, or JSON syntax error. Claude Desktop silently ignores malformed config and doesn't always surface a clear error.
+
+**Fix**
+
+1. Confirm the exact path:
+   - **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+   - **Linux:** `~/.config/Claude/claude_desktop_config.json`
+2. Validate the JSON:
+   ```bash
+   cat ~/Library/Application\ Support/Claude/claude_desktop_config.json | python3 -m json.tool
+   ```
+3. Fully quit Claude Desktop (Cmd-Q / right-click → Quit — closing the window is not enough) and relaunch.
+4. Common syntax pitfalls:
+   - Trailing commas after the last object key (not allowed in JSON).
+   - Unescaped backslashes in Windows paths — use forward slashes or double-backslashes.
+   - `env` values must be strings — wrap numbers in quotes.
+
+---
+
+## Claude Code vs `npx` caching
+
+**Symptom**
+`npm` published a new version but Claude Code keeps running the old one.
+
+**Cause**
+`npx -y mcp-server-scf` downloads to a per-user cache (`~/.npm/_npx/…`) and reuses it until the version on disk is older than the latest registry version. With no version pin, the resolution is fast but can lag by one version if npm's metadata is cached.
+
+**Fix**
+
+- Force the latest: `npx -y mcp-server-scf@latest`.
+- Clear the npx cache once: `rm -rf ~/.npm/_npx` then restart the MCP client.
+- Pin a specific version in config: `"args": ["-y", "mcp-server-scf@0.6.0"]`.
+
+---
+
+## Cursor / Windsurf config quirks
+
+**Symptom**
+The server works in Claude Desktop but not in Cursor or Windsurf.
+
+**Cause**
+These clients use slightly different config schemas and tend to validate strictly:
+
+- Cursor expects `.cursor/mcp.json` at the workspace root for project-scoped servers, or `~/.cursor/mcp.json` for user-scoped.
+- Windsurf uses `~/.codeium/windsurf/mcp_config.json`.
+- Both run the server with a much more restricted PATH than a login shell — `npx` may not be found.
+
+**Fix**
+
+1. Use an absolute `command` path:
+   ```json
+   "command": "/opt/homebrew/bin/npx"
+   ```
+2. Match the exact key casing expected — `mcpServers` (camelCase), not `mcp_servers`.
+3. Restart the IDE after any config change.
+4. Check the IDE's developer console / log viewer for stderr from the server.
+
+---
+
+## Node version / ESM gotchas
+
+**Symptom**
+Server exits immediately with `SyntaxError: Cannot use import statement outside a module` or `ERR_UNKNOWN_FILE_EXTENSION`.
+
+**Cause**
+Node < 18 doesn't support the ESM features this package relies on, and the shipped binary uses `.js` extensions with an explicit `"type": "module"` in package.json.
+
+**Fix**
+
+1. Upgrade to Node 18 LTS or newer:
+   ```bash
+   node --version   # must be v18.x or above
+   ```
+2. If you're using a version manager (`nvm`, `fnm`, `volta`), make sure the MCP client inherits the right version. Claude Desktop launches with whatever `node` is first on the system PATH — not your shell's PATH. Fix by:
+   - Symlinking the right binary into `/usr/local/bin/node`, or
+   - Using an absolute path in the client config: `"command": "/Users/you/.nvm/versions/node/v20.11.1/bin/npx"`.
+3. Avoid Node 19 — it's not an LTS line and some MCP SDK features regressed there. Prefer 18, 20, or 22.
+
+---
+
+## Capturing verbose logs for bug reports
+
+**Symptom**
+Something is broken, and you need to send logs with your issue — but the output looks empty.
+
+**Cause**
+The server never writes to stdout (that would corrupt the MCP protocol). All diagnostics go to stderr, which most MCP clients swallow by default.
+
+**Fix**
+
+**Claude Desktop:**
+
+```bash
+tail -f ~/Library/Logs/Claude/mcp-server-scf.log          # macOS
+# or
+tail -f "$APPDATA\Claude\logs\mcp-server-scf.log"         # Windows
+```
+
+**Claude Code:**
+
+```bash
+claude mcp logs scf
+```
+
+**Cursor / Windsurf:** open the IDE's developer console (View → Toggle Developer Tools → Console).
+
+**MCP Inspector (recommended for reproducing bugs):**
+
+```bash
+SCF_API_KEY=scf_your_key npx @modelcontextprotocol/inspector node build/index.js
+```
+
+The Inspector shows every tool call's request, response, and stderr output side-by-side — the fastest way to capture a clean repro.
+
+**Redaction.** Before pasting logs into an issue, run them through a filter to strip the key:
+
+```bash
+sed -E 's/scf_[A-Za-z0-9_-]+/scf_REDACTED/g' mcp-server-scf.log
+```
+
+The bug report template includes a mandatory "I have redacted API keys, tokens, and PII" checkbox for exactly this reason.


### PR DESCRIPTION
## Summary

Batch D of the v0.6.0 professional-review workstream. Trims the monolithic README and establishes a per-domain reference under ``docs/``.

- README: **687 → 198 lines** (well under the <250 target in #56).
- 11 new doc files totalling ~1,450 lines; every tool's parameters sourced directly from the Zod schemas in ``src/tools/*.ts``.
- Closes the documentation gaps the old README carried: all 19 evidence tools, all 12 risk tools, all 9 capability tools, and the entire 6-tool **webhooks** domain (which had never been documented anywhere).

## Linked issues

Closes #56
Closes #55

## What landed

### New per-domain docs — ``docs/tools/*.md``

| Doc                          | Tools | Notes                                                     |
| ---------------------------- | ----- | --------------------------------------------------------- |
| ``catalog.md``               | 6     | Read-only SCF reference data                              |
| ``scoped-controls.md``       | 6     | 8-state implementation workflow + L0–L5 maturity          |
| ``evidence.md``              | 19    | CRUD + files + validation + per-file AI + windowed AI     |
| ``risk.md``                  | 12    | Risk register + custom risks + control mappings           |
| ``vendors.md``               | 7     | TPRM + AI research + DPSIA                                |
| ``organization.md``          | 7     | User, orgs, audit, notifications                          |
| ``capabilities.md``          | 9     | KSI scorecard + evidence posture + systems inventory      |
| ``webhooks.md``              | 6     | **Previously undocumented** — authored from source         |

Each file: purpose paragraph, tool list with parameter tables, 3–4 example prompts.

### New platform/process docs

- ``docs/architecture.md`` — process model, source layout, request flow, error-code → user-message mapping, rate limits, "what this server does *not* do".
- ``docs/authentication.md`` — key format (``scf_`` prefix), per-client env block patterns (Desktop/Code/Cursor/Windsurf/Docker), region selection, rotation procedure, role-based permissions.
- ``docs/troubleshooting.md`` — 8 symptom → cause → fix triplets per #55 (401, region, 429, Desktop config, ``npx`` caching, Cursor/Windsurf quirks, Node/ESM, log capture).

### README rewrite

- Keeps the ``**72 tools**`` hero line — CI drift check still passes.
- Adds a one-liner at the top of the hero: *"Having trouble? → docs/troubleshooting.md · API key setup → docs/authentication.md · How it works → docs/architecture.md"*.
- Replaces the ~450-line parameter-table section with a link-out table pointing at each ``docs/tools/*.md``.
- Everything under ``## Documentation`` is new — central index pointing into the new docs.

## Risks & how they were de-risked

- **Tool-count drift check** ([ci.yml:47](.github/workflows/ci.yml)): scans ``**N tools**`` in README vs ``server.tool(`` in src. Ran locally → ``actual=72 readme=72`` ✅
- **Dead links**: every ``docs/…`` href in README.md was auto-audited against the filesystem — all 11 resolve.
- **Prettier on .github/workflows/**: untouched (still in ``.prettierignore`` for the OIDC exact-match rule).
- **Content accuracy**: every parameter description is lifted verbatim from the Zod ``.describe()`` in src. Zero paraphrasing.

## Test plan

Local checks all green before push:

- [x] ``npm run format:check`` — clean
- [x] ``npm run lint`` — 0 errors (the two pre-existing ``any`` warnings in ``src/tools/vendors.ts`` are unchanged)
- [x] ``npm run build`` — tsc strict passes
- [x] ``npm test`` — 29/29 pass
- [x] Manual drift check: ``actual=72 readme=72``
- [x] Manual dead-link audit on README → docs/ paths: 11/11 OK
- [x] Husky pre-commit hook ran on commit
- [ ] CI green on this PR
- [ ] Manual spot-check of the rendered README + a couple of ``docs/tools/*.md`` pages on GitHub after merge