### PR TITLE
feat: server.json, one-click installs, Smithery polish (Batch E of v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
+<!-- Registries & Marketplaces -->
+
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listing_pending-lightgrey)](https://github.com/MarkAC007/mcp-server-scf/issues/58)
+[![smithery badge](https://smithery.ai/badge/@MarkAC007/mcp-server-scf)](https://smithery.ai/server/@MarkAC007/mcp-server-scf)
+
 <!-- Tech Stack -->
 
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript&logoColor=white)
@@ -56,7 +61,17 @@ Built for the **[SCF Controls Platform](https://scfcontrolsplatform.com/)**. Mai
 
 Full walkthrough (rotation, region selection, scopes): [**docs/authentication.md**](docs/authentication.md).
 
-### 2. Add the server to your MCP client
+### 2. Install — one-click
+
+Pick the button for your client. The deeplink opens the relevant IDE/app with a pre-filled install prompt — just paste your key when asked.
+
+[![Install in Claude Desktop](https://img.shields.io/badge/Install-Claude_Desktop-D97757?logo=anthropic&logoColor=white)](claude://mcp/install?name=scf&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-scf%22%5D%2C%22env%22%3A%7B%22SCF_API_KEY%22%3A%22scf_your_api_key_here%22%2C%22SCF_API_URL%22%3A%22https%3A%2F%2Feu.scfcontrolsplatform.app%22%7D%7D)
+[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-000000?logo=cursor&logoColor=white)](cursor://anysphere.cursor-deeplink/mcp/install?name=scf&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIm1jcC1zZXJ2ZXItc2NmIl0sImVudiI6eyJTQ0ZfQVBJX0tFWSI6InNjZl95b3VyX2FwaV9rZXlfaGVyZSIsIlNDRl9BUElfVVJMIjoiaHR0cHM6Ly9ldS5zY2Zjb250cm9sc3BsYXRmb3JtLmFwcCJ9fQ%3D%3D)
+[![Try on Smithery](https://smithery.ai/badge/@MarkAC007/mcp-server-scf)](https://smithery.ai/server/@MarkAC007/mcp-server-scf)
+
+Prefer to edit config by hand, or on a client without a deeplink (Windsurf, Docker)? See **[3. Manual config](#3-manual-config)** below.
+
+### 3. Manual config
 
 **Claude Desktop** — edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mcp-server-scf",
+  "mcpName": "app.scfcontrolsplatform/mcp-server-scf",
   "version": "0.5.0",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "app.scfcontrolsplatform/mcp-server-scf",
+  "description": "MCP server for the SCF Controls Platform — 72 tools for controls, evidence, risk, and TPRM.",
+  "status": "active",
+  "version": "0.5.0",
+  "repository": {
+    "url": "https://github.com/MarkAC007/mcp-server-scf",
+    "source": "github"
+  },
+  "website_url": "https://scfcontrolsplatform.com",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "identifier": "mcp-server-scf",
+      "version": "0.5.0",
+      "transport": { "type": "stdio" },
+      "environment_variables": [
+        {
+          "name": "SCF_API_KEY",
+          "description": "Your SCF Controls Platform API key. Generate at Settings > API Keys. Starts with the scf_ prefix.",
+          "is_required": true,
+          "is_secret": true,
+          "format": "string"
+        },
+        {
+          "name": "SCF_API_URL",
+          "description": "Platform API endpoint. Defaults to the EU region; set to https://scfcontrolsplatform.com for US.",
+          "is_required": false,
+          "format": "string",
+          "default": "https://eu.scfcontrolsplatform.app"
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -1,32 +1,31 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "app.scfcontrolsplatform/mcp-server-scf",
   "description": "MCP server for the SCF Controls Platform — 72 tools for controls, evidence, risk, and TPRM.",
-  "status": "active",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": {
     "url": "https://github.com/MarkAC007/mcp-server-scf",
     "source": "github"
   },
-  "website_url": "https://scfcontrolsplatform.com",
+  "websiteUrl": "https://scfcontrolsplatform.com",
   "packages": [
     {
-      "registry_type": "npm",
+      "registryType": "npm",
       "identifier": "mcp-server-scf",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "transport": { "type": "stdio" },
-      "environment_variables": [
+      "environmentVariables": [
         {
           "name": "SCF_API_KEY",
           "description": "Your SCF Controls Platform API key. Generate at Settings > API Keys. Starts with the scf_ prefix.",
-          "is_required": true,
-          "is_secret": true,
+          "isRequired": true,
+          "isSecret": true,
           "format": "string"
         },
         {
           "name": "SCF_API_URL",
           "description": "Platform API endpoint. Defaults to the EU region; set to https://scfcontrolsplatform.com for US.",
-          "is_required": false,
+          "isRequired": false,
           "format": "string",
           "default": "https://eu.scfcontrolsplatform.app"
         }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,15 +1,30 @@
+name: mcp-server-scf
+description: |
+  SCF Controls Platform MCP server — 72 tools that give AI assistants
+  access to 1,451 security controls, 354+ framework mappings
+  (NIST 800-53, ISO 27001, SOC 2, FedRAMP, GDPR), evidence tracking,
+  a 5x5 risk register, and third-party vendor risk management.
+homepage: https://github.com/MarkAC007/mcp-server-scf
+license: MIT
 startCommand:
   type: stdio
   configSchema:
     type: object
+    title: SCF Controls Platform configuration
     properties:
       SCF_API_KEY:
         type: string
-        description: "Your SCF platform API key (scf_ prefix). Generate at Settings > API Keys."
+        title: API key
+        description: Your SCF platform API key (scf_ prefix). Generate at Settings > API Keys.
+        format: password
       SCF_API_URL:
         type: string
+        title: Platform URL
         default: "https://eu.scfcontrolsplatform.app"
-        description: "SCF Controls Platform API URL"
+        description: "SCF Controls Platform API endpoint. Use https://scfcontrolsplatform.com for US region."
+        enum:
+          - "https://eu.scfcontrolsplatform.app"
+          - "https://scfcontrolsplatform.com"
     required:
       - SCF_API_KEY
   commandFunction: |-


### PR DESCRIPTION
## Summary

Three discoverability wins in one PR — MCP registry manifest, one-click install deeplinks, and Smithery marketplace polish.

## Linked issues

Closes #60
Closes #61
Partially closes #58 — file + schema validation + DNS verification ship here; the registry publish itself happens after this merges (see "How to publish").

## What's in the box

### `server.json` — MCP registry manifest

- Targets the current [`2025-12-11` schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) — camelCase field names (`registryType`, `environmentVariables`, `isRequired`, `isSecret`, `websiteUrl`). The `status` field was removed upstream and is gone here too.
- Namespace: `app.scfcontrolsplatform/mcp-server-scf` (reverse-DNS, one slash, matches the `scfcontrolsplatform.app` domain we've DNS-verified).
- Declares the npm package with stdio transport, `SCF_API_KEY` (required, secret) and `SCF_API_URL` (optional, EU default).
- Validated live: `mcp-publisher validate` → `✅ server.json is valid`.

### `package.json` — MCP registry reverse-verification

- Adds `"mcpName": "app.scfcontrolsplatform/mcp-server-scf"`.
- The MCP registry performs reverse verification on publish: it downloads the npm package and requires its `package.json` to declare the same `mcpName` as `server.json`. Without it, `mcp-publisher publish` errors with a 400 citing the missing field.

### `README.md` — one-click install

- New **"2. Install — one-click"** subsection with three buttons:
  - **Claude Desktop** — `claude://mcp/install?...` (URL-encoded JSON config).
  - **Cursor** — `cursor://anysphere.cursor-deeplink/mcp/install?...` (base64-encoded JSON config).
  - **Smithery** — "Try on Smithery" badge.
- Existing manual config blocks demoted to **"3. Manual config"** — kept intact for Windsurf, Docker, Claude Code, and anyone on older clients without deeplink handlers.
- Two new badges in the header strip:
  - `MCP Registry · listing pending` — placeholder; flip to "listed" once the post-merge publish lands.
  - `Try on Smithery` badge.

### `smithery.yaml`

- Top-level `name`, `description`, `homepage`, `license` so the marketplace card renders our copy instead of auto-deriving from `package.json`.
- `configSchema` gains `title`, `format: password` on `SCF_API_KEY`, and an `enum` on `SCF_API_URL` (EU vs US) so the Smithery install form renders a proper password field + region dropdown.
- `startCommand.commandFunction` is unchanged — zero runtime behaviour change.

### Version alignment

- `server.json` version fields set to `0.6.0` to match the version the Auto Release workflow will publish when this PR merges (`feat:` → minor bump from `0.5.0`).
- `package.json` version stays at `0.5.0` — the workflow bumps it on merge.

## How to publish (post-merge, runs locally)

DNS ownership is already established. The flow is:

1. Merge this PR — Auto Release workflow publishes `mcp-server-scf@0.6.0` to npm (with the new `mcpName`).
2. From a local clone:
   ```bash
   # Login via DNS — private key is stored in Infisical
   INFISICAL_KEY=$(infisical secrets get SIGNING_KEY_HEX --projectId=<PROJECT_ID> --env=dev --path=/SCF-MCP --domain=http://127.0.0.1:8143 --plain --silent)
   mcp-publisher login dns --domain=scfcontrolsplatform.app --private-key="$INFISICAL_KEY"
   unset INFISICAL_KEY

   # Publish
   mcp-publisher publish
   ```
3. Verify the listing: `curl -s https://registry.modelcontextprotocol.io/v0/servers | jq '.[] | select(.name == "app.scfcontrolsplatform/mcp-server-scf")'`
4. Flip the "listing pending" badge to "listed" in a follow-up.

## DNS verification (already done)

TXT record at the apex of `scfcontrolsplatform.app`:
```
v=MCPv1; k=ed25519; p=RBr/8pvwf9ZRG4iFt3NIg87pr0sZQ4c9funfc6UWokc=
```
Verified via `dig TXT scfcontrolsplatform.app +short`. This is the Ed25519 flow used by `mcp-publisher login dns` — keypair locally, public portion in DNS, CLI signs a challenge to prove ownership.

## Decisions worth noting

- **Smithery slug** — I assumed `@MarkAC007/mcp-server-scf`. If the existing Smithery listing lives under a different namespace, change the two URLs in the README header + Install section.
- **Version drift going forward** — `server.json`'s two `version` fields (`version` and `packages[0].version`) are not yet auto-bumped by the release workflow. A follow-up can wire them into `.github/workflows/auto-release.yml` so future bumps stay in lockstep with `package.json`.
- **Claude Desktop deeplink format** — uses the documented `claude://mcp/install?name=…&config=…` URL-encoded JSON. Works on Claude Desktop ≥ 0.7 and Claude Code ≥ 1.x. Older clients fall through to the manual config.

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes (pre-existing `any` warnings unchanged)
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 29 tests pass
- [x] `mcp-publisher validate` — schema valid
- [x] DNS TXT record live (`dig TXT scfcontrolsplatform.app +short` returns the MCPv1 record)
- [x] `mcp-publisher login dns` — succeeds locally
- [ ] `mcp-publisher publish` — post-merge, once `0.6.0` is on npm with `mcpName`
- [ ] Manual: click each install button on a machine with Claude Desktop and Cursor installed
