### PR TITLE
fix: sync versions to v0.5.12 + flip registry badge to listed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <!-- Registries & Marketplaces -->
 
-[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listing_pending-lightgrey)](https://github.com/MarkAC007/mcp-server-scf/issues/58)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-green)](https://registry.modelcontextprotocol.io/v0/servers?search=scfcontrolsplatform)
 [![smithery badge](https://smithery.ai/badge/@MarkAC007/mcp-server-scf)](https://smithery.ai/server/@MarkAC007/mcp-server-scf)
 
 <!-- Tech Stack -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-server-scf",
-  "version": "0.5.0",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-server-scf",
-      "version": "0.5.0",
+      "version": "0.5.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-server-scf",
   "mcpName": "app.scfcontrolsplatform/mcp-server-scf",
-  "version": "0.5.0",
+  "version": "0.5.12",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "app.scfcontrolsplatform/mcp-server-scf",
   "description": "MCP server for the SCF Controls Platform — 72 tools for controls, evidence, risk, and TPRM.",
-  "version": "0.6.0",
+  "version": "0.5.12",
   "repository": {
     "url": "https://github.com/MarkAC007/mcp-server-scf",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "mcp-server-scf",
-      "version": "0.6.0",
+      "version": "0.5.12",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {


### PR DESCRIPTION
## Summary

Post-#86 cleanup. The MCP registry publish succeeded (`app.scfcontrolsplatform/mcp-server-scf@0.5.12` is live), but two drift issues remained on main. This PR realigns versions and flips the README badge.

## What happened on merge

- **npm publish worked** — Auto Release shipped `mcp-server-scf@0.5.12` with provenance + the new `mcpName`.
- **`package.json` version didn't sync** — the workflow's "commit package.json bump back to main" step was blocked by branch protection, so main's `package.json` still said `0.5.0` while npm was at `0.5.12`.
- **Version calc was wrong** — #86 set `server.json` to `0.6.0` expecting a minor bump (PR title `feat:`, current npm `0.5.11`). But the workflow uses `git describe --tags --abbrev=0` which walked commit ancestors and returned `v0.1.7` (not the highest semver tag). That cascaded through the reconcile step (max of 0.2.0 / 0.5.0 / 0.5.11 = npm's 0.5.11) and ended in a patch bump to `0.5.12`.

## Changes

- `package.json`: `0.5.0` → `0.5.12` (matches the provenance-signed npm artifact).
- `package-lock.json`: regenerated via `npm install --package-lock-only`.
- `server.json`: top-level + `packages[0]` version → `0.5.12`.
- `README.md`: MCP Registry badge flipped from `listing_pending` (grey, pointing at #58) to `listed` (green, linking to `registry.modelcontextprotocol.io/v0/servers?search=scfcontrolsplatform`).

## Registry listing (live)

```
Name:        app.scfcontrolsplatform/mcp-server-scf
Version:     0.5.12
Status:      active
isLatest:    true
publishedAt: 2026-04-18T17:20:13Z
```

Verify: `curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=scfcontrolsplatform" | jq`

## Follow-up (separate issue/PR)

The `git describe --tags --abbrev=0` in `.github/workflows/auto-release.yml` (Get latest tag version step) should be replaced with something that picks the highest semver tag — e.g. `git tag --sort=-v:refname | head -1`. Otherwise every release is at risk of the same miscalculation.

Happy to open that as a dedicated issue so it closes #58 cleanly once fixed.

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes (2 pre-existing `any` warnings unchanged)
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 29 tests pass
- [x] `mcp-publisher validate` — schema valid against `2025-12-11`
- [x] Registry API returns the listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)