### PR TITLE
fix(ci): use highest semver tag in auto-release.yml (closes #88)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,8 +33,13 @@ jobs:
       - name: Get latest tag version
         id: latest_tag
         run: |
-          # Get latest tag, default to v0.0.0 if none exists
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Get highest semver tag, default to v0.0.0 if none exists.
+          # Uses --sort=-v:refname to pick the highest version independent of
+          # commit-graph proximity; `git describe --tags --abbrev=0` returns
+          # the nearest ancestor tag, which can be stale on branches with
+          # scattered tag history (see #88).
+          LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+          LATEST_TAG="${LATEST_TAG:-v0.0.0}"
           VERSION="${LATEST_TAG#v}"
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

One-line fix to the tag lookup in `auto-release.yml`. Closes #88.

## The bug

`git describe --tags --abbrev=0` returns the **nearest tag reachable from `HEAD`** by commit ancestry — not the highest semver tag. When release tags are scattered across branches (or an older tag happens to be "closer" by graph distance), this returns a stale tag and every downstream calculation in the workflow is wrong.

#86's merge landed here: `git describe` returned `v0.1.7` as "latest", the minor-bump math produced `0.2.0`, the reconcile step maxed that against npm's `0.5.11`, and the workflow patch-bumped to `0.5.12` instead of the expected `0.6.0`. Full trace in #88.

## The fix

```diff
-          # Get latest tag, default to v0.0.0 if none exists
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Get highest semver tag, default to v0.0.0 if none exists.
+          # Uses --sort=-v:refname to pick the highest version independent of
+          # commit-graph proximity; `git describe --tags --abbrev=0` returns
+          # the nearest ancestor tag, which can be stale on branches with
+          # scattered tag history (see #88).
+          LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+          LATEST_TAG="${LATEST_TAG:-v0.0.0}"
```

`git tag --sort=-v:refname` sorts by semantic version descending, independent of commit graph. The `v*` list filter keeps release tags and ignores any non-version tags that might exist.

## Verification

Run locally against this repo's current tags:

```
$ git describe --tags --abbrev=0
v0.1.7                               ← stale ancestor (the bug)

$ git tag --list 'v*' --sort=-v:refname | head -n 1
v0.5.13                              ← correct highest (the fix)
```

Once this merges, the next `feat:` PR will bump from `v0.5.13` → `0.6.0` as intended by the v0.6.0 milestone.

## Out of scope (for now)

The related silent-drift issue flagged in #88 — the "Update package.json version" step emits a `::warning::` and moves on when branch protection blocks the push-back, rather than opening a follow-up PR or failing the build. Worth tackling separately; keeping this PR to the minimum fix so it's easy to review and revert if anything surprises the next release.

## Test plan

- [x] `git tag --list 'v*' --sort=-v:refname | head -n 1` returns `v0.5.13` on main
- [x] `npm run format:check` passes
- [x] Diff is a single-line substitution in `.github/workflows/auto-release.yml`; OIDC/identity blocks untouched
- [ ] Next `feat:` PR merge produces the expected minor bump (validated on the next Batch F or G merge)
