### PR TITLE
fix: remove references to a non-existent US region

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For Claude Desktop ≥ 0.11.0, the easiest install is a signed `.mcpb` bundle �
 3. When prompted, paste your `scf_…` API key. It's stored in your OS keychain, not in a config file.
 4. Claude Desktop restarts the server and all 72 tools are available.
 
-To uninstall or swap regions later: **Settings → Extensions → SCF Controls Platform → Configure**. The `Platform URL` field lets you switch between `https://uk.scfcontrolsplatform.app` (default, UK data residency) and `https://scfcontrolsplatform.com` (US).
+To uninstall or update the API key later: **Settings → Extensions → SCF Controls Platform → Configure**.
 
 ### 3. Manual config
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -6,9 +6,7 @@
 
 ## Getting an API key
 
-1. Sign up or sign in at your region's platform URL:
-   - **UK (default):** [uk.scfcontrolsplatform.app](https://uk.scfcontrolsplatform.app)
-   - **US:** [scfcontrolsplatform.com](https://scfcontrolsplatform.com)
+1. Sign up or sign in at [uk.scfcontrolsplatform.app](https://uk.scfcontrolsplatform.app) (UK data residency).
 2. Open **Settings → API Keys**.
 3. Click **Generate New Key**.
 4. Copy the key immediately — it's shown once. Keys are stored server-side as SHA-256 hashes and cannot be recovered after the dialog closes.
@@ -100,16 +98,9 @@ The `-e SCF_API_KEY` flag (without a value) passes the variable through from the
 
 ---
 
-## Region selection
+## Platform URL
 
-`SCF_API_URL` selects the platform region. Pick the endpoint that matches where your data is hosted:
-
-| Region | `SCF_API_URL`                                  | Platform console             |
-| ------ | ---------------------------------------------- | ---------------------------- |
-| UK     | `https://uk.scfcontrolsplatform.app` (default) | `uk.scfcontrolsplatform.app` |
-| US     | `https://scfcontrolsplatform.com`              | `scfcontrolsplatform.com`    |
-
-An API key issued in one region **will not work** against the other. Using the wrong URL produces `401 Authentication failed` — the most common cause of a working account reporting auth errors.
+The platform runs in the UK (`https://uk.scfcontrolsplatform.app`) — this is the default and currently the only region. `SCF_API_URL` exists so future regions can be selected without a code change; for now, leave it unset or set it to the UK URL explicitly.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,23 +30,20 @@ One of:
 
 ---
 
-## Region selection: UK vs US
+## Wrong `SCF_API_URL`
 
 **Symptom**
-Key looks correct (starts with `scf_`, length matches) but every request returns `401`.
+Key looks correct (starts with `scf_`, length matches) but every request returns `401` or `ENOTFOUND`.
 
 **Cause**
-API keys are region-scoped. A key minted on `uk.scfcontrolsplatform.app` will not authenticate against `scfcontrolsplatform.com` (US) and vice versa.
+`SCF_API_URL` is pointing at the wrong host. The platform currently runs only at `https://uk.scfcontrolsplatform.app` — any other value will fail.
 
 **Fix**
-Set `SCF_API_URL` to match the region where the key was issued:
+Leave `SCF_API_URL` unset (the default already targets the UK host) or set it explicitly to:
 
-| Region | `SCF_API_URL`                                  |
-| ------ | ---------------------------------------------- |
-| UK     | `https://uk.scfcontrolsplatform.app` (default) |
-| US     | `https://scfcontrolsplatform.com`              |
-
-If you're unsure, log into the platform console — the domain in the browser tells you the region.
+```
+SCF_API_URL=https://uk.scfcontrolsplatform.app
+```
 
 ---
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -55,7 +55,7 @@
     "api_url": {
       "type": "string",
       "title": "Platform URL",
-      "description": "SCF Controls Platform endpoint. Defaults to the UK region (https://uk.scfcontrolsplatform.app). Use https://scfcontrolsplatform.com for the US region.",
+      "description": "SCF Controls Platform endpoint. Defaults to https://uk.scfcontrolsplatform.app (UK data residency).",
       "required": false,
       "default": "https://uk.scfcontrolsplatform.app"
     }

--- a/server.json
+++ b/server.json
@@ -24,7 +24,7 @@
         },
         {
           "name": "SCF_API_URL",
-          "description": "Platform API endpoint. Defaults to the UK region; set to https://scfcontrolsplatform.com for US.",
+          "description": "Platform API endpoint. Defaults to https://uk.scfcontrolsplatform.app (UK data residency).",
           "isRequired": false,
           "format": "string",
           "default": "https://uk.scfcontrolsplatform.app"

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -21,10 +21,7 @@ startCommand:
         type: string
         title: Platform URL
         default: "https://uk.scfcontrolsplatform.app"
-        description: "SCF Controls Platform API endpoint. Use https://scfcontrolsplatform.com for US region."
-        enum:
-          - "https://uk.scfcontrolsplatform.app"
-          - "https://scfcontrolsplatform.com"
+        description: "SCF Controls Platform API endpoint (UK data residency)."
     required:
       - SCF_API_KEY
   commandFunction: |-


### PR DESCRIPTION
## Summary

- **Follow-up to [#92](https://github.com/MarkAC007/mcp-server-scf/pull/92)** — drops every reference to a non-existent US region. The platform currently runs only in the UK; `scfcontrolsplatform.com` is the marketing/signup site, not a regional API endpoint.
- This commit was pushed to #92 shortly before the squash-merge and didn't make the cut.

## What changed

| File | Change |
|------|--------|
| `mcpb/manifest.json` | Platform URL description no longer mentions `scfcontrolsplatform.com` / US |
| `smithery.yaml` | Removed `"https://scfcontrolsplatform.com"` from the `SCF_API_URL` `enum`; description simplified to "UK data residency" |
| `server.json` | `SCF_API_URL` description is UK-only |
| `README.md` | Extensions-configure note no longer offers a US toggle |
| `docs/authentication.md` | "Region selection" table collapsed into a UK-only "Platform URL" note; sign-up step points at the UK URL |
| `docs/troubleshooting.md` | "Region selection: UK vs US" renamed to "Wrong `SCF_API_URL`" with UK-only guidance |

Marketing links to https://scfcontrolsplatform.com are kept — that's the public website and signup origin, not a regional API host.

## Test plan

- [x] `npm run format:check` → clean
- [x] `npm run lint` → 0 errors, 2 pre-existing warnings
- [x] `npx tsc --noEmit` → clean
- [x] `npm test` → 29/29 passing
- [x] `grep -n "US region\|(US)\|for US\|UK vs US\|scfcontrolsplatform\.com for"` → 0 matches across the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
