### PR TITLE
chore(deps): migrate to TypeScript 6.0 (closes #90)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
         "vitest": "^3.2.4"
       },
@@ -5459,9 +5459,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
     "vitest": "^3.2.4"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
+    "types": ["node"],
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

Migrates the repo from TypeScript 5.x to TypeScript 6.0. Closes #90.

TypeScript 6 changed its default behaviour for `@types/*` auto-discovery — `@types/node` is no longer implicitly included unless `compilerOptions.types` names it explicitly. Under 5.x this was silent; under 6.x the build failed with TS2591 errors for every `process.*` and `node:*` reference in `src/`.

## Changes

- `tsconfig.json`: add `"types": ["node"]` to `compilerOptions`
- `package.json`: bump devDep `typescript` `^5.7.0` → `^6.0.3`
- `package-lock.json`: regenerated for the new TS version (rebased on top of #98/#99, so the lockfile was rebuilt from scratch — larger diff than the two-line source change suggests, but semantically just the TS bump)

## Compatibility check

- `typescript-eslint@8.58.2` peerDep: `typescript >=4.8.4 <6.1.0` → 6.0.3 supported, no coordinated bump needed
- `@modelcontextprotocol/sdk@1.29.0` has no typescript peer dep
- `vitest@3.2.4` / `@vitest/coverage-v8@3.2.4` don't pin typescript
- TS 6 engines `node>=14.17` → CI matrix (20/22) unaffected

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm run lint` — 0 errors (2 pre-existing `no-explicit-any` warnings in `src/tools/vendors.ts`, unrelated)
- [x] `npm run format:check` — passes
- [x] `npm test` — 37/37 vitest tests pass
- [ ] Green CI across Node 20 / 22 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)