### PR TITLE
chore: polish batch — FUNDING, CODEOWNERS, badges, Inspector quickstart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner for everything in the repo.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/managing-repository-settings/about-code-owners
+*                    @MarkAC007
+
+# Security-sensitive surfaces — keep explicit even though the default already routes here,
+# so future reviewers see the intent when ownership expands.
+/.github/            @MarkAC007
+/SECURITY.md         @MarkAC007
+/src/lib/api-client.ts  @MarkAC007

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: MarkAC007

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 [![npm version](https://img.shields.io/npm/v/mcp-server-scf.svg)](https://www.npmjs.com/package/mcp-server-scf)
 [![npm downloads](https://img.shields.io/npm/dm/mcp-server-scf)](https://www.npmjs.com/package/mcp-server-scf)
+[![install size](https://img.shields.io/packagephobia/install/mcp-server-scf)](https://packagephobia.com/result?p=mcp-server-scf)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 
@@ -27,7 +28,7 @@
 
 <!-- Tech Stack -->
 
-![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-blue?logo=typescript&logoColor=white)
 ![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=node.js&logoColor=white)
 
 **Security compliance controls, frameworks, and risk management for AI agents.**
@@ -56,6 +57,20 @@ Built for the **[SCF Controls Platform](https://scfcontrolsplatform.com/)**. Mai
 | [Organization](docs/tools/organization.md)       | 7     | Users, orgs, audit trail, work queue, notifications                                   |
 | [Capabilities](docs/tools/capabilities.md)       | 9     | KSI capability themes, scorecards, evidence posture, systems inventory                |
 | [Webhooks](docs/tools/webhooks.md)               | 6     | Webhook endpoints, delivery logs, secret rotation                                     |
+
+---
+
+## Try it with MCP Inspector
+
+Kick the tires without adding the server to a client — [MCP Inspector](https://github.com/modelcontextprotocol/inspector) launches a local UI that introspects every tool, its schema, and its description:
+
+```bash
+npx @modelcontextprotocol/inspector npx -y mcp-server-scf
+```
+
+Inspector opens on `http://localhost:6274` and connects to `mcp-server-scf` over stdio. You'll see all 72 tools, grouped by domain, with their Zod schemas rendered as a live form.
+
+Live tool calls need an API key — export `SCF_API_KEY` in the same shell before launching Inspector, or set it under the "Environment Variables" tab inside the Inspector UI. Without a key, you can still browse schemas and descriptions; tool calls return 401.
 
 ---
 


### PR DESCRIPTION
## Summary

Burns down the P3 polish-batch issues as a single PR. Closes #75, #76, #77, #78.

## Changes

### #75 — `.github/FUNDING.yml`
Points to the `MarkAC007` GitHub Sponsors profile. Uncontroversial default for a solo-maintainer public repo; remove or edit if sponsor routing shouldn't land here.

### #76 — `.github/CODEOWNERS`
Default owner `@MarkAC007` with explicit entries for security-sensitive surfaces (`.github/`, `SECURITY.md`, `src/lib/api-client.ts`). **Follow-up:** branch protection in GitHub settings still needs to be updated to require CODEOWNERS review on protected files — the file alone is advisory.

### #77 — README badges
- Bumped stale static **TypeScript** badge `5` → `6` (repo is on `typescript ^6.0.3` after #101).
- Added **packagephobia install-size** badge in the Package & License group.
- Left gated badges alone: coverage (awaiting a coverage workflow) and browser bundle size (N/A for a stdio CLI).

### #78 — MCP Inspector quickstart
New **Try it with MCP Inspector** section between Overview and Quick Start, with the zero-clone npx one-liner:

```bash
npx @modelcontextprotocol/inspector npx -y mcp-server-scf
```

Notes `localhost:6274`, how to browse schemas without an API key, and where to set `SCF_API_KEY` for live calls. Screenshot deferred — can be added as a follow-up.

## Test plan

- [x] `npm run build` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — 0 errors (2 pre-existing warnings, unrelated)
- [x] `npm run format:check` — passes
- [x] `npm test` — 37/37 vitest tests pass
- [x] README tool-count CI invariant: source `server.tool(` count = 72, README claims `**72 tools**`
- [ ] Green CI across Node 20 / 22 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)