### PR TITLE
ci: sync server.json on release + weekly drift health check (closes #100)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -131,20 +131,28 @@ jobs:
           echo "version=$FINAL_VERSION" >> $GITHUB_OUTPUT
           echo "Final version: v$FINAL_VERSION"
 
-      - name: Update package.json version
+      - name: Update package.json and server.json versions
         run: |
           NEW_VERSION="${{ steps.final_version.outputs.version }}"
           npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
 
-          if git diff --quiet package.json package-lock.json; then
+          # Keep server.json in lockstep with package.json so the MCP Registry
+          # metadata tracks the npm release. Two fields need the bump: the
+          # top-level .version and the npm package entry .packages[0].version.
+          jq --arg v "$NEW_VERSION" \
+            '.version = $v | (.packages[] | select(.registryType == "npm") | .version) |= $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+          if git diff --quiet package.json package-lock.json server.json; then
             echo "No version changes needed"
           else
-            git add package.json package-lock.json
-            git commit -m "chore(release): bump package.json to v${NEW_VERSION}"
+            git add package.json package-lock.json server.json
+            git commit -m "chore(release): bump package.json + server.json to v${NEW_VERSION}"
             if git push origin main; then
-              echo "Updated package.json to v${NEW_VERSION}"
+              echo "Updated package.json + server.json to v${NEW_VERSION}"
             else
-              echo "::warning::Could not push version update to main (branch protection). Update package.json manually or via next PR."
+              echo "::warning::Could not push version update to main (branch protection). Update package.json + server.json manually or via next PR."
             fi
           fi
 

--- a/.github/workflows/release-health-check.yml
+++ b/.github/workflows/release-health-check.yml
@@ -1,0 +1,102 @@
+name: Release Health Check
+
+# Catches silent drift across the four places the release version lives:
+#   - npm registry  (`npm view mcp-server-scf@latest version`)
+#   - git tags      (highest `v*` tag)
+#   - server.json   (top-level .version AND .packages[0].version)
+#   - MCP Registry  (app.scfcontrolsplatform/mcp-server-scf current .version)
+#
+# Runs weekly on Monday morning and on-demand. Fails loudly if any surface
+# has drifted from the rest so a silent publish miss or a forgotten server.json
+# bump is caught within a week, not when a user reports it.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Mondays, 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Verify release surfaces are in sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # need full tag history
+
+      - name: Read release versions from each surface
+        id: versions
+        run: |
+          NPM_VERSION=$(npm view mcp-server-scf@latest version 2>/dev/null || echo "")
+          GIT_TAG_VERSION=$(git tag --list 'v*' --sort=-v:refname | head -n 1 | sed 's/^v//')
+          SERVER_JSON_TOP=$(jq -r '.version' server.json)
+          SERVER_JSON_PKG=$(jq -r '.packages[] | select(.registryType == "npm") | .version' server.json)
+
+          MCP_NAMESPACE="app.scfcontrolsplatform/mcp-server-scf"
+          REGISTRY_JSON=$(curl -fsSL \
+            --max-time 30 \
+            "https://registry.modelcontextprotocol.io/v0/servers?search=${MCP_NAMESPACE}")
+          REGISTRY_VERSION=$(echo "$REGISTRY_JSON" | jq -r \
+            --arg name "$MCP_NAMESPACE" \
+            '.servers[] | select(.server.name == $name) | .server.version' \
+            | head -n 1)
+
+          {
+            echo "npm=$NPM_VERSION"
+            echo "git=$GIT_TAG_VERSION"
+            echo "server_json_top=$SERVER_JSON_TOP"
+            echo "server_json_pkg=$SERVER_JSON_PKG"
+            echo "registry=$REGISTRY_VERSION"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compare and report
+        env:
+          NPM: ${{ steps.versions.outputs.npm }}
+          GIT: ${{ steps.versions.outputs.git }}
+          SERVER_TOP: ${{ steps.versions.outputs.server_json_top }}
+          SERVER_PKG: ${{ steps.versions.outputs.server_json_pkg }}
+          REGISTRY: ${{ steps.versions.outputs.registry }}
+        run: |
+          # Always print the table so it's visible in the job summary regardless of pass/fail.
+          {
+            echo "## Release surface versions"
+            echo ""
+            echo "| Surface                        | Version       |"
+            echo "|--------------------------------|---------------|"
+            echo "| npm (\`latest\` dist-tag)        | \`${NPM:-<empty>}\` |"
+            echo "| Highest \`v*\` git tag           | \`${GIT:-<empty>}\` |"
+            echo "| \`server.json\` top-level        | \`${SERVER_TOP:-<empty>}\` |"
+            echo "| \`server.json\` packages[0]      | \`${SERVER_PKG:-<empty>}\` |"
+            echo "| MCP Registry                   | \`${REGISTRY:-<empty>}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Any empty value is a fetch failure, not a drift — treat as fail either way.
+          fail=0
+          for v in "$NPM" "$GIT" "$SERVER_TOP" "$SERVER_PKG" "$REGISTRY"; do
+            if [ -z "$v" ]; then fail=1; fi
+          done
+
+          # Drift check: npm, git, and server.json must all match.
+          # MCP Registry is allowed to lag npm because publishing there is currently
+          # manual (see project memory: domain-auth namespace blocks OIDC). Warn on
+          # registry drift instead of failing until the publish step is automated.
+          if [ -n "$NPM" ] && [ -n "$GIT" ] && [ -n "$SERVER_TOP" ] && [ -n "$SERVER_PKG" ]; then
+            if [ "$NPM" != "$GIT" ] || [ "$NPM" != "$SERVER_TOP" ] || [ "$NPM" != "$SERVER_PKG" ]; then
+              fail=1
+              echo "::error::npm / git tag / server.json drift detected — see summary table"
+            fi
+          fi
+
+          if [ -n "$NPM" ] && [ -n "$REGISTRY" ] && [ "$NPM" != "$REGISTRY" ]; then
+            echo "::warning::MCP Registry (${REGISTRY}) lags npm (${NPM}). Publish manually: \`mcp-publisher publish\` after \`mcp-publisher login dns --domain scfcontrolsplatform.app\`."
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "All in-repo surfaces (npm / git / server.json) agree on v${NPM}."


### PR DESCRIPTION
## Summary

Two surgical additions to close #100.

1. **`auto-release.yml`** now bumps `server.json` alongside `package.json` in the release-prep commit. A `jq` step patches both the top-level `.version` and any `.packages[]` entry with `registryType: "npm"` in lockstep with the reconciled release version. Same commit, same push attempt — when the push succeeds, MCP Registry metadata stays current with npm automatically, no separate manual edit.

2. **`release-health-check.yml`** (new, weekly on Monday 09:00 UTC + `workflow_dispatch`) reads the release version from four surfaces — npm `latest`, highest `v*` git tag, `server.json` (top-level + `packages[0]`), and the MCP Registry API — prints them as a summary table, and fails CI if the in-repo surfaces (npm / git / `server.json`) disagree. MCP Registry drift emits a **warning** rather than a failure, because publishing there is currently manual (see below).

## Findings snapshot (taken 2026-04-19)

| Surface                | Version  | Notes                                                                 |
| ---------------------- | -------- | --------------------------------------------------------------------- |
| npm latest             | `1.0.6`  | signed with provenance, `.mcpb` attached to the GH release            |
| highest `v*` git tag   | `v1.0.6` | tag push from auto-release works fine                                 |
| `package.json` on main | `0.5.12` | stale — auto-release push to main is blocked by branch protection     |
| `server.json` on main  | `0.5.12` | stale — was never bumped alongside `package.json` until this PR       |
| MCP Registry           | `0.5.12` | published 2026-04-18, no CI automation today                          |

## Out of scope — flagged for follow-up issues

- **Branch-protection blocking the auto-release bump commit.** The current workflow's "Update package.json version" step fails with `GH006: Protected branch update failed for refs/heads/main` every cycle. The warning fires, the release continues (npm publish + tag creation both take their own paths and succeed), but `package.json` / `server.json` never catch up on main. Fix requires either a GitHub settings change (bypass rule for `github-actions[bot]`) or an auth surface change (PAT with admin bypass, GitHub App token). This PR doesn't touch it.

- **Auto-publishing to the MCP Registry from CI.** The namespace `app.scfcontrolsplatform/*` is a domain-owned namespace (reverse-DNS of `scfcontrolsplatform.app`) — it **cannot** use GitHub OIDC. CI automation needs DNS or HTTP domain auth: signing key stored as a secret + matching TXT record on `scfcontrolsplatform.app` (or a `/.well-known/mcp-registry-auth` served from that origin). Needs a decision on auth mechanism before it can be wired up.

Both should probably become their own issues.

## Test plan

- [x] Both workflow files parse under `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] `jq` transformation against current `server.json` produces the expected bumped output (simulated bump to `1.0.7`, top-level and `packages[0].version` both updated, all other fields preserved)
- [x] Local CI mirror green (build, lint, tests, format:check)
- [ ] Green CI on the PR
- [ ] Manual `workflow_dispatch` of the new health check after merge — should report the current known drift (`server.json` / MCP Registry at `0.5.12` vs npm `1.0.6+`) and fail, confirming the check is wired correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)