### PR TITLE
ci(auto-release): sync main via PR instead of blocked push (closes #104)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -12,13 +12,17 @@ permissions:
 jobs:
   release:
     name: Release & Publish
-    if: github.event.pull_request.merged == true
+    # Skip on our own version-bump PRs — otherwise each release triggers a
+    # new release when its bump PR merges, looping forever.
+    if: |
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.title, 'chore(release):')
     runs-on: ubuntu-latest
     environment: npm  # Link to GitHub Environment for OIDC
     permissions:
-      contents: write       # push version bump commit + git tag + GitHub Release
-      id-token: write       # npm OIDC trusted publishing (provenance)
-      pull-requests: read   # read merged PR metadata for release notes
+      contents: write        # push tag + GitHub Release + bump branch
+      id-token: write        # npm OIDC trusted publishing (provenance)
+      pull-requests: write   # open the version-bump PR that syncs main
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -149,11 +153,7 @@ jobs:
           else
             git add package.json package-lock.json server.json
             git commit -m "chore(release): bump package.json + server.json to v${NEW_VERSION}"
-            if git push origin main; then
-              echo "Updated package.json + server.json to v${NEW_VERSION}"
-            else
-              echo "::warning::Could not push version update to main (branch protection). Update package.json + server.json manually or via next PR."
-            fi
+            echo "Staged version bump commit locally — will open a PR after the release is recorded (direct push to main is blocked by branch protection)."
           fi
 
       - name: Create and push tag
@@ -292,6 +292,41 @@ jobs:
           files: ${{ steps.build_mcpb.outputs.path }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open version-bump PR to sync main with the release
+        # Runs after the release is durably recorded (tag + GH release + npm publish),
+        # so a failure here never blocks or corrupts the release itself.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.final_version.outputs.version }}
+        run: |
+          # The bump commit has been sitting on local HEAD since the "Update
+          # package.json and server.json versions" step — git tag already
+          # annotated it, and it will travel to origin via this PR instead of
+          # the blocked direct-to-main push.
+          if ! git diff --quiet "origin/main" HEAD -- package.json package-lock.json server.json; then
+            BUMP_BRANCH="chore/release-bump-v${NEW_VERSION}"
+
+            if ! git push origin "HEAD:refs/heads/${BUMP_BRANCH}" 2>&1; then
+              echo "::warning::Could not push ${BUMP_BRANCH} — main will stay stale until manually synced."
+              exit 0
+            fi
+
+            gh pr create \
+              --base main \
+              --head "${BUMP_BRANCH}" \
+              --title "chore(release): bump to v${NEW_VERSION}" \
+              --body "Auto-opened by \`auto-release.yml\` after v${NEW_VERSION} was published to npm. Brings \`package.json\`, \`package-lock.json\`, and \`server.json\` on \`main\` in line with the release so \`release-health-check.yml\` stays green."
+
+            # Try to enable auto-merge. If the repo doesn't allow auto-merge
+            # (settings) or required checks are already green and merging via
+            # --auto isn't needed, the fallback just leaves the PR for manual
+            # merge — not a failure mode worth failing the release over.
+            gh pr merge "${BUMP_BRANCH}" --auto --squash --delete-branch 2>&1 \
+              || echo "::notice::Version-bump PR opened — merge manually if auto-merge isn't enabled in repo settings."
+          else
+            echo "No version bump needed — package.json + server.json already match main."
+          fi
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Closes #104. Root cause of the `server.json` / `package.json` drift surfaced in #100: `auto-release.yml` pushes the version-bump commit straight to the default branch, and branch protection rejects it (`GH006: Protected branch update failed`) every release. The warning fires, the release continues, but the source-of-truth files on `main` never catch up with npm.

Fix: flow the bump through a short-lived branch + auto-merging PR instead of a direct push.

## Changes to `.github/workflows/auto-release.yml`

1. **Job `if` clause** now skips when the merged PR title starts with `chore(release):`, so the bump PR the workflow itself opens doesn't trigger a new release (would loop forever).
2. **Permissions:** `pull-requests` bumped `read` → `write` so the job can open its own PR.
3. **"Update package.json and server.json versions" step** no longer attempts the blocked direct-to-main push. It just stages the bump commit locally. The existing "Create and push tag" step still annotates that local commit, so the tag tree is unchanged.
4. **New "Open version-bump PR to sync main with the release" step**, placed after "Create GitHub Release" so the release is durably recorded before we attempt the sync PR. Pushes the bump to a fresh `chore/release-bump-v<ver>` branch, opens a PR, and asks GitHub to auto-merge (squash + delete branch). If auto-merge isn't enabled in repo settings, the PR sits waiting for a human — not a failure mode worth failing the release over.

## How the loop is avoided

The bump PR's squash merge lands a commit whose title is `chore(release): bump to vX.Y.Z (#NNN)` on `main`. The `if:` filter then skips auto-release on that PR's merge event. No infinite loop.

## What this PR does NOT change

- Tag creation / push — unchanged, tag continues to annotate the local bump commit
- `npm publish --provenance` — unchanged, still consumes the locally-bumped `package.json`
- `.mcpb` build + upload — unchanged
- Release notes / `CHANGELOG` — unchanged
- Any `src/` or test code

## Test plan

- [x] Workflow parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Build, lint (0 errors), `format:check`, vitest (37/37) — all green
- [ ] CI green on this PR (existing matrix: Node 20 / 22 + SAST + CodeQL + Secret Detection + Socket + Registry Signature)
- [ ] Observed next release cycle: first release after merge produces a clean `chore(release): bump to vX.Y.Z` PR, auto-merges (if enabled) or waits for review, lands bump on `main`, `release-health-check.yml` goes green on next manual dispatch
- [ ] Observed: auto-release does **not** re-trigger on the bump PR's merge

## Follow-up consideration

If Jeff prefers to turn OFF branch protection's "Require PRs" rule for `github-actions[bot]` (via a bypass list), this whole fix becomes unnecessary — the original direct-push approach would work. That's a repo-settings choice, not code. This PR is the code-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
