### PR TITLE
ci: dispatch CI against auto-release bump PRs (fixes #106 stuck state)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -318,10 +318,19 @@ jobs:
               --title "chore(release): bump to v${NEW_VERSION}" \
               --body "Auto-opened by \`auto-release.yml\` after v${NEW_VERSION} was published to npm. Brings \`package.json\`, \`package-lock.json\`, and \`server.json\` on \`main\` in line with the release so \`release-health-check.yml\` stays green."
 
-            # Try to enable auto-merge. If the repo doesn't allow auto-merge
-            # (settings) or required checks are already green and merging via
-            # --auto isn't needed, the fallback just leaves the PR for manual
-            # merge — not a failure mode worth failing the release over.
+            # PRs created via GITHUB_TOKEN don't trigger workflows (GitHub
+            # anti-loop rule), so the required status checks on `main`'s
+            # branch protection (`build (20)`, `build (22)`, etc.) would
+            # never fire for this PR on their own — leaving it stuck in
+            # mergeable_state="blocked" forever. Explicitly dispatch ci.yml
+            # against the bump branch to produce those check runs.
+            gh workflow run ci.yml --ref "${BUMP_BRANCH}" 2>&1 \
+              || echo "::warning::Could not dispatch ci.yml against ${BUMP_BRANCH} — the bump PR will need required checks satisfied another way."
+
+            # Try to enable auto-merge. Requires the repo's "Allow auto-merge"
+            # setting (Settings -> General) to be on; if it isn't, the fallback
+            # leaves the PR waiting for a manual merge — not a failure mode
+            # worth failing the release over.
             gh pr merge "${BUMP_BRANCH}" --auto --squash --delete-branch 2>&1 \
               || echo "::notice::Version-bump PR opened — merge manually if auto-merge isn't enabled in repo settings."
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Explicit dispatch endpoint so auto-release.yml can kick this workflow
+  # against bot-created bump branches (see #104/#105). PRs opened by
+  # GITHUB_TOKEN don't trigger workflows on their own (GitHub anti-loop
+  # rule), so the required status checks would never fire for those PRs
+  # without an explicit dispatch.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Follow-up to #105 surfaced when release [v1.0.8](https://github.com/MarkAC007/mcp-server-scf/releases/tag/v1.0.8) landed on npm: the auto-opened bump PR ([#106](https://github.com/MarkAC007/mcp-server-scf/pull/106)) sat in `mergeable_state: blocked` because its required status checks never fired.

Root cause: GitHub's anti-loop rule — **PRs opened by `GITHUB_TOKEN` don't trigger workflows**. Branch protection on `main` requires `build (20)`, `build (22)`, SAST, CodeQL, Secret Detection, Socket, Registry Signature — all of which only run on `push` / `pull_request`. None of them fire for a bot-opened PR, so the PR stays blocked forever and `--auto` squash-merge never trips.

This also explains the `release-health-check.yml` failure Jeff observed: `server.json` and `package.json` on `main` are still at `1.0.7` while npm is at `1.0.8`, because #106 can't merge.

## Fix

Two tiny changes that together let the existing #105 flow actually complete:

1. **`.github/workflows/ci.yml`** — add `workflow_dispatch:` as an explicit trigger. Zero behavior change for the normal `push` / `pull_request` cases.
2. **`.github/workflows/auto-release.yml`** — after `gh pr create` opens the bump PR, call `gh workflow run ci.yml --ref "${BUMP_BRANCH}"` to dispatch a CI run against the bump branch. This produces the check runs required by branch protection. `gh pr merge --auto --squash --delete-branch` then merges the PR once those checks go green.

The dispatch has a `|| echo "::warning::..."` fallback — if it fails, we surface a warning but don't fail the release.

## How this unblocks the existing stuck PR

PR [#106](https://github.com/MarkAC007/mcp-server-scf/pull/106) was opened before this fix landed, so its checks were never dispatched. Two options once this PR merges:

- **Manual one-time unblock:** `gh workflow run ci.yml --ref chore/release-bump-v1.0.8` — the existing `--auto` merge on #106 will then trip when CI finishes.
- **Or just close #106 and wait** — next release will cut a fresh bump PR that goes through the full fixed flow end-to-end.

Either path will clear the `release-health-check.yml` drift.

## Also recommended (Jeff-side, repo settings)

- Enable **Settings → General → Allow auto-merge**. `gh pr merge --auto` is a no-op if the repo setting is off; we'd fall through to the "merge manually" notice unnecessarily.

## What this PR does NOT change

- Branch protection rules — unchanged
- Release publishing flow (npm, tag, GH release, `.mcpb` build) — unchanged
- Any `src/` or test code — unchanged
- MCP Registry auto-publish — separate follow-up (needs DNS auth on `scfcontrolsplatform.app`)

## Test plan

- [x] Both workflow files parse as valid YAML
- [x] Local build, lint (0 errors), `format:check`, vitest (37/37) — all green
- [ ] This PR's own CI matrix green (Node 20 / 22 + SAST + CodeQL + Secret Detection + Socket + Registry Signature) — verifies `workflow_dispatch` addition didn't break normal `pull_request` triggering
- [ ] Observed on next release cycle: bump PR auto-opens, CI dispatches against bump branch, checks go green, `--auto` squash-merges, `release-health-check.yml` goes clean on next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
