### PR TITLE
ci: auto-publish to MCP Registry (DNS auth) + fix actions:write for dispatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,6 +23,7 @@ jobs:
       contents: write        # push tag + GitHub Release + bump branch
       id-token: write        # npm OIDC trusted publishing (provenance)
       pull-requests: write   # open the version-bump PR that syncs main
+      actions: write         # dispatch ci.yml against the bump branch (workflow_dispatch)
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -193,6 +194,44 @@ jobs:
       - name: Publish to npm with provenance
         if: steps.check_published.outputs.skip != 'true'
         run: npm publish --provenance --access public
+
+      - name: Publish to MCP Registry (DNS-auth)
+        # Publishes server.json to registry.modelcontextprotocol.io so the
+        # `app.scfcontrolsplatform/mcp-server-scf` entry stays in lockstep
+        # with npm. Auth is DNS domain verification on scfcontrolsplatform.app
+        # because GitHub OIDC only works for `io.github.*` namespaces.
+        #
+        # Non-fatal by design: if the secret isn't set (initial bootstrap),
+        # or the publish call fails for any reason, we surface a warning but
+        # don't fail the release — npm + tag + GH release have already
+        # succeeded by this point.
+        #
+        # Prerequisites (one-time, Jeff-side — see PR body for full setup):
+        #   1. `openssl genpkey -algorithm Ed25519 -out key.pem` locally
+        #   2. Add DNS TXT record on scfcontrolsplatform.app apex:
+        #        "v=MCPv1; k=ed25519; p=<base64_public_key>"
+        #   3. `gh secret set MCP_REGISTRY_KEY --body "<hex_private_key>"`
+        if: steps.check_published.outputs.skip != 'true'
+        env:
+          MCP_REGISTRY_KEY: ${{ secrets.MCP_REGISTRY_KEY }}
+          MCP_DOMAIN: scfcontrolsplatform.app
+        run: |
+          if [ -z "$MCP_REGISTRY_KEY" ]; then
+            echo "::notice::MCP_REGISTRY_KEY secret not set — skipping MCP Registry publish. See PR #109 for one-time setup."
+            exit 0
+          fi
+
+          # Download the latest mcp-publisher release binary.
+          curl -sSfL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+          ./mcp-publisher login dns --domain "$MCP_DOMAIN" --private-key "$MCP_REGISTRY_KEY" \
+            || { echo "::warning::mcp-publisher DNS login failed — check DNS TXT record propagation on $MCP_DOMAIN."; exit 0; }
+
+          ./mcp-publisher publish \
+            || { echo "::warning::mcp-publisher publish failed — MCP Registry may lag npm until manually resynced."; exit 0; }
+
+          echo "Published server.json to MCP Registry."
 
       - name: Build .mcpb Desktop Extension bundle
         id: build_mcpb


### PR DESCRIPTION
## Summary

Two linked changes, both in `auto-release.yml`:

1. **Fixes the HTTP 403 from the v1.0.9 release** (`run 24623321714`): `gh workflow run ci.yml --ref chore/release-bump-v1.0.9` failed with `Resource not accessible by integration` because `GITHUB_TOKEN` lacks `actions: write`. This left [PR #108](https://github.com/MarkAC007/mcp-server-scf/pull/108) with only Socket checks — none of the required `build (20)`, `build (22)`, SAST, CodeQL, Secret Detection fired. Adding `actions: write` to the job's permissions block lets `GITHUB_TOKEN` dispatch the workflow. (Per GitHub docs, `workflow_dispatch` is an explicit exception to the anti-loop rule that normally prevents `GITHUB_TOKEN`-triggered events from running workflows.)

2. **Auto-publishes `server.json` to the MCP Registry** after a successful npm publish, using DNS domain verification on `scfcontrolsplatform.app`. Closes the last remaining source of drift flagged by `release-health-check.yml`: currently npm is at `1.0.9` but MCP Registry is still at `0.5.12`, because publishing was manual.

## Why DNS auth (not GitHub OIDC)

GitHub OIDC only issues tokens for the `io.github.*` namespace. Our server name is `app.scfcontrolsplatform/mcp-server-scf`, which maps to the `scfcontrolsplatform.app` domain under reverse-DNS rules, so we need domain verification instead. DNS was chosen over HTTP because it doesn't couple release pipeline health to the production web server being up.

## One-time Jeff-side setup required

The step is **guarded** — it no-ops with a `::notice::` if `MCP_REGISTRY_KEY` is unset, so this PR can merge safely before setup. When you're ready to enable auto-publish, do these three steps locally (takes ~5 min + DNS propagation):

### 1. Generate an Ed25519 keypair

```bash
# Generate the private key
openssl genpkey -algorithm Ed25519 -out mcp-registry-key.pem

# Extract base64 public key (for the DNS TXT record)
PUBLIC_KEY="$(openssl pkey -in mcp-registry-key.pem -pubout -outform DER | tail -c 32 | base64)"
echo "Public key (for DNS): $PUBLIC_KEY"

# Extract hex private key (for the GitHub secret)
PRIVATE_KEY="$(openssl pkey -in mcp-registry-key.pem -noout -text | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n')"
echo "Private key (for secret): $PRIVATE_KEY"
```

Store `mcp-registry-key.pem` somewhere safe (password manager) — you won't need it again unless you rotate.

### 2. Add DNS TXT record on `scfcontrolsplatform.app`

At the **apex** (not a subdomain) of `scfcontrolsplatform.app`:

```
Name:  @           (or scfcontrolsplatform.app.)
Type:  TXT
Value: v=MCPv1; k=ed25519; p=<PASTE_PUBLIC_KEY_HERE>
TTL:   default (300s fine)
```

Propagation usually completes in a few minutes; verify with:

```bash
dig +short TXT scfcontrolsplatform.app | grep MCPv1
```

### 3. Set the GitHub Actions secret

```bash
gh secret set MCP_REGISTRY_KEY \
  --repo MarkAC007/mcp-server-scf \
  --body "<PASTE_PRIVATE_KEY_HEX_HERE>"
```

### 4. (Optional) Manual first publish to close the v0.5.12 → v1.0.9 gap

Auto-publish will kick in on the *next* release. To resync the MCP Registry immediately without waiting for another release:

```bash
# From the repo root on main, once #108 has merged and server.json shows v1.0.9:
curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_darwin_$(uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/').tar.gz" | tar xz mcp-publisher
./mcp-publisher login dns --domain scfcontrolsplatform.app --private-key "$PRIVATE_KEY"
./mcp-publisher publish
```

## Behaviour without the secret

If `MCP_REGISTRY_KEY` is unset, the step emits a GitHub Actions notice and exits 0. Release continues normally; `release-health-check.yml` keeps surfacing the MCP Registry drift as a `::warning::` (not a fail).

## Test plan

- [x] YAML parses valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Local build / lint (0 errors) / format:check / vitest (37/37) — all green
- [ ] CI green on this PR
- [ ] Observed after merge: next release either publishes to MCP Registry (if secret set) or cleanly no-ops with a notice
- [ ] Observed after merge: auto-release's `gh workflow run ci.yml --ref ...` no longer 403s (confirmed by next bump PR's build (20)/(22) checks actually appearing)

## Follow-ups NOT in scope

- DNS setup + secret provisioning (Jeff-side, this PR documents the steps)
- Unblocking the currently-stuck [PR #108](https://github.com/MarkAC007/mcp-server-scf/pull/108) — needs a manual force-merge or a re-run from `main` after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
