### PR TITLE
ci(health-check): filter MCP Registry response by isLatest

### DIFF
--- a/.github/workflows/release-health-check.yml
+++ b/.github/workflows/release-health-check.yml
@@ -40,9 +40,17 @@ jobs:
           REGISTRY_JSON=$(curl -fsSL \
             --max-time 30 \
             "https://registry.modelcontextprotocol.io/v0/servers?search=${MCP_NAMESPACE}")
+          # The registry returns ALL versions of a server; pick the one flagged
+          # as `isLatest: true`. Naïvely taking the first match grabs whatever
+          # came back first from the search (often the oldest), which is what
+          # made the check report `0.5.12` while the registry actually had
+          # `1.0.10` indexed as latest.
           REGISTRY_VERSION=$(echo "$REGISTRY_JSON" | jq -r \
             --arg name "$MCP_NAMESPACE" \
-            '.servers[] | select(.server.name == $name) | .server.version' \
+            '.servers[]
+               | select(.server.name == $name)
+               | select(._meta["io.modelcontextprotocol.registry/official"].isLatest == true)
+               | .server.version' \
             | head -n 1)
 
           {


### PR DESCRIPTION
## Why

The release health check reported this after v1.0.10 landed:

| Surface | Reported |
|---|---|
| npm (latest) | 1.0.10 |
| git tag | 1.0.10 |
| server.json top | 1.0.10 |
| server.json packages[0] | 1.0.10 |
| **MCP Registry** | **0.5.12** ❌ |

That's wrong — the registry actually has `1.0.10` indexed as the current version. `mcp-publisher publish` succeeded in [auto-release run 24623567619](https://github.com/MarkAC007/mcp-server-scf/actions/runs/24623567619) with `✓ Successfully published`.

Root cause: the registry's `/v0/servers?search=...` endpoint returns **every** published version of a server, not just the latest. The old jq filter selected by `name` then took `head -n 1`, which grabbed whichever entry the search ranked first — in practice, the oldest publish. After v1.0.10 was added, v0.5.12 still came back first in the search response.

## Fix

Filter by the `_meta["io.modelcontextprotocol.registry/official"].isLatest` flag that the registry attaches to exactly one entry per server. One-line-of-logic change to the existing jq expression.

Verified live:

```
$ curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=app.scfcontrolsplatform/mcp-server-scf" \
    | jq -r '.servers[] | select(.server.name == "app.scfcontrolsplatform/mcp-server-scf") | select(._meta["io.modelcontextprotocol.registry/official"].isLatest == true) | .server.version'
1.0.10
```

## Test plan

- [x] YAML parses valid
- [x] jq filter returns `1.0.10` against the live registry
- [ ] After merge, `workflow_dispatch` run of `release-health-check.yml` reports MCP Registry = `1.0.10` and exits 0 (no drift, no warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)