### PR TITLE
feat(tools): add control-composite read tools — get + list (M3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `scf_get_control_assessment_composite` tool — rolled-up assessment composite for a single SCF control (composite score, status band, included/missing evidence, mandatory gaps, per-window detail). Wraps `GET /organizations/{org_id}/controls/{scf_id}/assessment-composite`. Closes #569.
+- `scf_list_control_assessment_composites` tool — cursor-paginated organisation-wide list of rolled-up assessment composites ordered worst-band first, with `status`, `domain`, and `computation_version` filters. Wraps `GET /organizations/{org_id}/controls/assessment-composites`. Closes #569.
+
 ### Security
 - **Added `publishConfig.provenance: true`** to `package.json` so provenance is enforced regardless of how publish is invoked (belt-and-braces alongside `auto-release.yml`'s `--provenance` flag).
 - **Guarded `prepare: husky` script** (`husky || true`) so it no longer hard-fails consumer installs or `npm pack` when husky is absent. Removes the Socket.dev "install script risk" signal.

--- a/README.md
+++ b/README.md
@@ -45,18 +45,18 @@ Built for the **[SCF Controls Platform](https://scfcontrolsplatform.com/)**. Mai
 
 `mcp-server-scf` connects AI assistants to the [SCF Controls Platform](https://scfcontrolsplatform.com/) via MCP, enabling natural language interaction with your compliance program. Your AI can browse the full SCF control catalog, track implementation progress, manage evidence collection, assess risks, and monitor third-party vendors — all without leaving your editor or chat.
 
-**72 tools** across 8 domains — click through for full parameter tables and example prompts:
+**74 tools** across 8 domains — click through for full parameter tables and example prompts:
 
-| Domain                                           | Tools | Description                                                                           |
-| ------------------------------------------------ | ----- | ------------------------------------------------------------------------------------- |
-| [Catalog](docs/tools/catalog.md)                 | 6     | Browse 1,451 controls, 354+ frameworks, 5,736 assessment objectives                   |
-| [Control Scoping](docs/tools/scoped-controls.md) | 6     | Track implementation status across an 8-state workflow                                |
-| [Evidence](docs/tools/evidence.md)               | 19    | Manage evidence collection, validation, maturity scoring, and windowed AI assessments |
-| [Risk Management](docs/tools/risk.md)            | 12    | 5x5 risk matrix, risk register, custom risks and control mapping                      |
-| [Vendor Risk (TPRM)](docs/tools/vendors.md)      | 7     | Vendor registry, AI-powered security research, DPSIA                                  |
-| [Organization](docs/tools/organization.md)       | 7     | Users, orgs, audit trail, work queue, notifications                                   |
-| [Capabilities](docs/tools/capabilities.md)       | 9     | KSI capability themes, scorecards, evidence posture, systems inventory                |
-| [Webhooks](docs/tools/webhooks.md)               | 6     | Webhook endpoints, delivery logs, secret rotation                                     |
+| Domain                                           | Tools | Description                                                                                                      |
+| ------------------------------------------------ | ----- | ---------------------------------------------------------------------------------------------------------------- |
+| [Catalog](docs/tools/catalog.md)                 | 6     | Browse 1,451 controls, 354+ frameworks, 5,736 assessment objectives                                              |
+| [Control Scoping](docs/tools/scoped-controls.md) | 6     | Track implementation status across an 8-state workflow                                                           |
+| [Evidence](docs/tools/evidence.md)               | 21    | Manage evidence collection, validation, maturity scoring, windowed AI assessments, and control-composite rollups |
+| [Risk Management](docs/tools/risk.md)            | 12    | 5x5 risk matrix, risk register, custom risks and control mapping                                                 |
+| [Vendor Risk (TPRM)](docs/tools/vendors.md)      | 7     | Vendor registry, AI-powered security research, DPSIA                                                             |
+| [Organization](docs/tools/organization.md)       | 7     | Users, orgs, audit trail, work queue, notifications                                                              |
+| [Capabilities](docs/tools/capabilities.md)       | 9     | KSI capability themes, scorecards, evidence posture, systems inventory                                           |
+| [Webhooks](docs/tools/webhooks.md)               | 6     | Webhook endpoints, delivery logs, secret rotation                                                                |
 
 ---
 
@@ -68,7 +68,7 @@ Kick the tires without adding the server to a client — [MCP Inspector](https:/
 npx @modelcontextprotocol/inspector npx -y mcp-server-scf
 ```
 
-Inspector opens on `http://localhost:6274` and connects to `mcp-server-scf` over stdio. You'll see all 72 tools, grouped by domain, with their Zod schemas rendered as a live form.
+Inspector opens on `http://localhost:6274` and connects to `mcp-server-scf` over stdio. You'll see all 74 tools, grouped by domain, with their Zod schemas rendered as a live form.
 
 Live tool calls need an API key — export `SCF_API_KEY` in the same shell before launching Inspector, or set it under the "Environment Variables" tab inside the Inspector UI. Without a key, you can still browse schemas and descriptions; tool calls return 401.
 
@@ -107,7 +107,7 @@ For Claude Desktop ≥ 0.11.0, the easiest install is a signed `.mcpb` bundle �
 1. Download `mcp-server-scf-<version>.mcpb` from the [latest GitHub release](https://github.com/MarkAC007/mcp-server-scf/releases/latest).
 2. Double-click the file (or drag it onto Claude Desktop → **Settings → Extensions**).
 3. When prompted, paste your `scf_…` API key. It's stored in your OS keychain, not in a config file.
-4. Claude Desktop restarts the server and all 72 tools are available.
+4. Claude Desktop restarts the server and all 74 tools are available.
 
 To uninstall or update the API key later: **Settings → Extensions → SCF Controls Platform → Configure**.
 

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -444,4 +444,64 @@ export function registerEvidenceTools(server: McpServer) {
       }
     },
   );
+
+  // ---------------------------------------------------------------------------
+  // Control Assessment Composite (M3 — issue #569)
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "scf_get_control_assessment_composite",
+    "Get the rolled-up assessment composite for one SCF control: composite score, status band, included/missing evidence IDs, mandatory gaps, and per-window detail. Returns 404 if no composite row exists yet (composites are produced asynchronously by the rollup service after window assessments fire).",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      scf_id: z.string().describe("SCF control identifier in DOMAIN-NN format (e.g., 'AST-01', 'GOV-02')"),
+    },
+    async ({ org_id, scf_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/controls/${scf_id}/assessment-composite`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_list_control_assessment_composites",
+    "List rolled-up assessment composites for the organisation. Cursor-paginated, ordered worst-band first (insufficient → sufficient) so weakest controls surface at the top. Use status/domain/computation_version filters to scope. Pass next_cursor from the previous response to page forward. Useful for finding controls with the weakest assessment-quality posture.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      status: z
+        .string()
+        .optional()
+        .describe(
+          "Comma-separated composite_status values to include (e.g., 'insufficient,partial'). Valid values: insufficient, insufficient_sample, partial, pending, no_evidence, sufficient",
+        ),
+      domain: z.string().optional().describe("Filter by SCF domain code (e.g., 'BCD', 'GOV', 'AST')"),
+      computation_version: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Restrict to composites computed at this algorithm version"),
+      limit: z.number().int().min(1).max(500).optional().default(100).describe("Page size (1–500, default 100)"),
+      cursor: z.string().optional().describe("Opaque pagination cursor — pass next_cursor from a prior response"),
+    },
+    async ({ org_id, status, domain, computation_version, limit, cursor }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/controls/assessment-composites`, {
+          status,
+          domain,
+          computation_version,
+          limit,
+          cursor,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
 }

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -451,7 +451,7 @@ export function registerEvidenceTools(server: McpServer) {
 
   server.tool(
     "scf_get_control_assessment_composite",
-    "Get the rolled-up assessment composite for one SCF control: composite score, status band, included/missing evidence IDs, mandatory gaps, and per-window detail. Returns 404 if no composite row exists yet (composites are produced asynchronously by the rollup service after window assessments fire).",
+    "Get the rolled-up assessment composite for one SCF control: composite score, status band, included/missing evidence IDs, mandatory gaps, per-window detail. 404 if no composite row exists yet (async).",
     {
       org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
       scf_id: z.string().describe("SCF control identifier in DOMAIN-NN format (e.g., 'AST-01', 'GOV-02')"),
@@ -469,7 +469,7 @@ export function registerEvidenceTools(server: McpServer) {
 
   server.tool(
     "scf_list_control_assessment_composites",
-    "List rolled-up assessment composites for the organisation. Cursor-paginated, ordered worst-band first (insufficient → sufficient) so weakest controls surface at the top. Use status/domain/computation_version filters to scope. Pass next_cursor from the previous response to page forward. Useful for finding controls with the weakest assessment-quality posture.",
+    "List rolled-up assessment composites for the org. Cursor-paginated, worst-band first (insufficient → sufficient). Filter by status/domain/computation_version. Pass next_cursor to page forward.",
     {
       org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
       status: z

--- a/tests/registration.test.ts
+++ b/tests/registration.test.ts
@@ -21,7 +21,7 @@ describe("tool registration", () => {
   const cases: Array<[string, (s: McpServer) => void, number]> = [
     ["catalog", registerCatalogTools, 6],
     ["scoped-controls", registerScopedControlTools, 6],
-    ["evidence", registerEvidenceTools, 19],
+    ["evidence", registerEvidenceTools, 21],
     ["risk", registerRiskTools, 12],
     ["vendors", registerVendorTools, 7],
     ["organization", registerOrganizationTools, 7],
@@ -61,9 +61,9 @@ describe("tool registration", () => {
     });
   }
 
-  it("total tool count equals 72", () => {
+  it("total tool count equals 74", () => {
     const server = makeMockServer();
     for (const [, register] of cases) register(server);
-    expect(server.tool).toHaveBeenCalledTimes(72);
+    expect(server.tool).toHaveBeenCalledTimes(74);
   });
 });


### PR DESCRIPTION
## Summary

- Add `scf_get_control_assessment_composite` — wraps `GET /organizations/{org_id}/controls/{scf_id}/assessment-composite`
- Add `scf_list_control_assessment_composites` — wraps `GET /organizations/{org_id}/controls/assessment-composites` (cursor-paginated, worst-band-first)
- Both READ-only, viewer+ RBAC, no auth surface changes
- CHANGELOG entry added under `[Unreleased]`
- **Version intentionally NOT bumped** — `auto-release.yml` infers from PR title (`feat:` → minor) on merge

## Why

Closes the consumer-side gap from scf-controls-platform epic #569 (closed 2026-05-09, M1a + M2 + M3 ramp complete on prod). M1a windowed-assessment tools shipped previously; this PR adds the M3 layer (`ControlAssessmentComposite`) which rolls per-control posture across multiple evidence IDs into a single score.

Without these wrappers, AI agents asking "what is the assessment-quality posture of control GOV-02?" had to manually aggregate per-window assessments across N mapped evidence IDs. The backend already computes the rollup via composite_service; these tools just expose it.

## Pattern

Both tools mirror the existing 5 M1a windowed-assessment tools in `src/tools/evidence.ts` exactly:
- Single `try { client.get(...) } catch { errorResult(...) }`
- No new imports — `z`, `getClient`, `errorResult` already in scope
- Section header comment (`// Control Assessment Composite (M3 — issue #569)`) for navigation

## Verification

- [x] `npx eslint src/tools/evidence.ts` → exit 0
- [x] `npm run build` → exit 0
- [x] `grep -c "scf_get_control_assessment_composite|scf_list_control_assessment_composites" build/tools/evidence.js` → 2 (both registered in compiled output)
- [x] `registration.test.ts` shape constraints satisfied (≤200 char descriptions, Zod `.describe()` on every param)

## Test plan

- [ ] CI green
- [ ] After merge + auto-release: install latest from npm, configure with `SCF_API_KEY`, run via MCP Inspector
- [ ] Verify `scf_get_control_assessment_composite` returns 404 for a control without a composite row yet (e.g., a control with no fired window assessments)
- [ ] Verify `scf_list_control_assessment_composites` returns rows ordered insufficient → sufficient (worst-band first)
- [ ] Verify status filter — `status: "insufficient,partial"` returns only those bands
- [ ] Verify cursor pagination — second call with `cursor: <response.next_cursor>` returns next page

## Audit trail

- Audit work dir: `~/.claude/MEMORY/WORK/20260512-145000_mcp-scf-windowed-assessment-audit/`
- Impl work dir: `~/.claude/MEMORY/WORK/20260512-150500_mcp-scf-composite-tools-impl/`
- Paired platform PR (catalog DTO fix surfacing `required_artifact_types`): MarkAC007/scf-controls-platform#608

Related: scf-controls-platform#569 (closed epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)