### PR TITLE
chore(deps): npm audit fix — resolve fast-uri/hono/ip-address advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3059,12 +3059,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3125,9 +3125,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -3531,9 +3531,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3642,9 +3642,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary

Runs `npm audit fix` (no `--force`) to resolve the 4 npm-audit advisories on `main`:

| Package | Severity | Bump |
|---|---|---|
| `fast-uri` | high | 3.1.0 → 3.1.2 |
| `hono` | moderate | 4.12.14 → 4.12.18 |
| `ip-address` | moderate | 8.3.2 → 8.5.1 |
| `express-rate-limit` | moderate | 10.1.0 → 10.2.0 |

All transitive; **no `package.json` direct-dep range changes**, only `package-lock.json`.

This unblocks the `npm audit --audit-level=high` hard-gate added in #113, which is currently red on every new PR (e.g. #128, which was admin-merged to unblock the feature shipment).

## Verification

- `npm audit` post-fix: `found 0 vulnerabilities` (was: 1 high + 3 moderate)
- `npm ci` clean
- `npm run build` exit 0
- `npm test` exit 0 (37/37 pass)
- Diff scope: only `package-lock.json` (13 +/- 13 lines)

Pre-existing lint errors on `main` (`5 errors / 12 warnings` from `no-undef 'fetch'`) are unchanged by this PR — separate cleanup needed.

## Test plan

- [x] `npm audit --audit-level=high` exits 0
- [x] `npm ci` reinstalls cleanly
- [x] Build + tests green
- [x] No source/test/doc changes — lockfile only

🤖 Generated with [Claude Code](https://claude.com/claude-code)