### PR TITLE
feat!: sync with self-hosted platform API; require SCF_API_URL (v1.7.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -76,8 +76,8 @@ body:
     id: api-url
     attributes:
       label: SCF_API_URL
-      description: Which platform endpoint are you hitting? (Do NOT paste the API key.)
-      placeholder: "https://uk.scfcontrolsplatform.app"
+      description: Which self-hosted platform endpoint are you hitting? Redact internal hostnames if needed. (Do NOT paste the API key.)
+      placeholder: "http://localhost:8000"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BREAKING
+- **`SCF_API_URL` is now required — the hosted SaaS default is gone.** The platform's hosted instance (`uk.scfcontrolsplatform.app`) was decommissioned; the SCF Controls Platform is self-hosted only. The client no longer falls back to the dead host: `getClient()` throws a setup-pointing error when `SCF_API_URL` is unset. `server.json`, `smithery.yaml`, and `mcpb/manifest.json` now mark the variable required with no default; README/docs rewritten around "your own instance" (deploy from [scf-controls-platform-oss](https://github.com/MarkAC007/scf-controls-platform-oss)). Anyone who relied on the default was already pointing at a dead host — set `SCF_API_URL` to your instance's base URL (e.g. `http://localhost:8000`).
+- **`scf_trigger_dpsia` removed, replaced by `scf_trigger_vendor_assessment`.** Platform PR scf-controls-platform#686 consolidated the vendor lifecycle: `POST …/vendors/{id}/assessments` is now an async AI-assessment trigger (HTTP 202) and the `/dpsia/*` paths are deprecated aliases whose old enum values (`new`, `annual-review`) no longer validate. The new tool keeps the auto-derive behaviour for `services_used` and uses the new `assessment_type` enum (`initial`/`annual`/`adhoc`). `client_name` is no longer accepted by the platform request schema and was dropped.
+
 ### Added
+- `scf_list_vendor_assessments`, `scf_get_latest_vendor_assessment`, `scf_get_vendor_assessment`, `scf_get_vendor_assessment_status` tools — full read surface for the new vendor AI assessments (scf-controls-platform#686), including RAG status, recommendation, `report_markdown`/`report_json`, research sources, and job polling.
+- `scf_list_system_catalog` + `scf_get_system_catalog_template` tools — browse the platform's DB-backed system knowledge catalog (templates, aliases, curated recipes). Wraps `GET /system-catalog[/{slug}]` (scf-controls-platform#689).
+- `scf_get_system_recipes`, `scf_generate_system_recipes`, `scf_get_recipe_generation_status` tools — per-system evidence-collection recipes with template/alias/fallback matching and async AI generation (scf-controls-platform#689).
+- `vendor_id` (structural vendor link, same-org validated) and `catalog_template_id` params on `scf_create_system` / `scf_update_system`, and a `vendor_id` filter on `scf_list_systems`; system responses now carry `vendor_id` + nested `linked_vendor` (scf-controls-platform#692).
+- `maturity_level` (`L0`–`L5`) param on `scf_create_evidence` / `scf_update_evidence` — evidence-tracking maturity now persists platform-side (scf-controls-platform#694).
+
+### Changed
+- Tool count 74 → 83 (vendors 7→11, capabilities 9→14); counts aligned across README, architecture docs, `server.json`, `mcpb/manifest.json`, `smithery.yaml`, and the banner asset.
+- HTTP 402 is now surfaced as "Usage limit reached on your instance…" instead of the SaaS-era "Subscription limit reached. Upgrade your plan." wording.
 - `scf_get_control_assessment_composite` tool — rolled-up assessment composite for a single SCF control (composite score, status band, included/missing evidence, mandatory gaps, per-window detail). Wraps `GET /organizations/{org_id}/controls/{scf_id}/assessment-composite`. Closes #569.
 - `scf_list_control_assessment_composites` tool — cursor-paginated organisation-wide list of rolled-up assessment composites ordered worst-band first, with `status`, `domain`, and `computation_version` filters. Wraps `GET /organizations/{org_id}/controls/assessment-composites`. Closes #569.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Built for the **[SCF Controls Platform](https://scfcontrolsplatform.com/)**. Mai
 
 `mcp-server-scf` connects AI assistants to the [SCF Controls Platform](https://scfcontrolsplatform.com/) via MCP, enabling natural language interaction with your compliance program. Your AI can browse the full SCF control catalog, track implementation progress, manage evidence collection, assess risks, and monitor third-party vendors — all without leaving your editor or chat.
 
-**74 tools** across 8 domains — click through for full parameter tables and example prompts:
+**83 tools** across 8 domains — click through for full parameter tables and example prompts:
 
 | Domain                                           | Tools | Description                                                                                                      |
 | ------------------------------------------------ | ----- | ---------------------------------------------------------------------------------------------------------------- |
@@ -55,9 +55,9 @@ Built for the **[SCF Controls Platform](https://scfcontrolsplatform.com/)**. Mai
 | [Control Scoping](docs/tools/scoped-controls.md) | 6     | Track implementation status across an 8-state workflow                                                           |
 | [Evidence](docs/tools/evidence.md)               | 21    | Manage evidence collection, validation, maturity scoring, windowed AI assessments, and control-composite rollups |
 | [Risk Management](docs/tools/risk.md)            | 12    | 5x5 risk matrix, risk register, custom risks and control mapping                                                 |
-| [Vendor Risk (TPRM)](docs/tools/vendors.md)      | 7     | Vendor registry, AI-powered security research, DPSIA                                                             |
+| [Vendor Risk (TPRM)](docs/tools/vendors.md)      | 11    | Vendor registry, AI security research, async AI assessments (replaces DPSIA)                                     |
 | [Organization](docs/tools/organization.md)       | 7     | Users, orgs, audit trail, work queue, notifications                                                              |
-| [Capabilities](docs/tools/capabilities.md)       | 9     | KSI capability themes, scorecards, evidence posture, systems inventory                                           |
+| [Capabilities](docs/tools/capabilities.md)       | 14    | KSI themes, scorecards, evidence posture, systems inventory, system catalog + AI recipes                         |
 | [Webhooks](docs/tools/webhooks.md)               | 6     | Webhook endpoints, delivery logs, secret rotation                                                                |
 
 ---
@@ -70,9 +70,9 @@ Kick the tires without adding the server to a client — [MCP Inspector](https:/
 npx @modelcontextprotocol/inspector npx -y mcp-server-scf
 ```
 
-Inspector opens on `http://localhost:6274` and connects to `mcp-server-scf` over stdio. You'll see all 74 tools, grouped by domain, with their Zod schemas rendered as a live form.
+Inspector opens on `http://localhost:6274` and connects to `mcp-server-scf` over stdio. You'll see all 83 tools, grouped by domain, with their Zod schemas rendered as a live form.
 
-Live tool calls need an API key — export `SCF_API_KEY` in the same shell before launching Inspector, or set it under the "Environment Variables" tab inside the Inspector UI. Without a key, you can still browse schemas and descriptions; tool calls return 401.
+Live tool calls need your instance's URL and an API key — export `SCF_API_URL` and `SCF_API_KEY` in the same shell before launching Inspector, or set them under the "Environment Variables" tab inside the Inspector UI. Without them, you can still browse schemas and descriptions; tool calls return a configuration error.
 
 ---
 
@@ -95,7 +95,9 @@ Pick the route for your client.
 
 **Cursor** — click the badge below. Cursor registers the `cursor://` scheme, so the deeplink opens the IDE with the server config pre-filled:
 
-[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-000000?logo=cursor&logoColor=white)](cursor://anysphere.cursor-deeplink/mcp/install?name=scf&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIm1jcC1zZXJ2ZXItc2NmIl0sImVudiI6eyJTQ0ZfQVBJX0tFWSI6InNjZl95b3VyX2FwaV9rZXlfaGVyZSIsIlNDRl9BUElfVVJMIjoiaHR0cHM6Ly91ay5zY2Zjb250cm9sc3BsYXRmb3JtLmFwcCJ9fQ%3D%3D)
+[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-000000?logo=cursor&logoColor=white)](cursor://anysphere.cursor-deeplink/mcp/install?name=scf&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIm1jcC1zZXJ2ZXItc2NmIl0sImVudiI6eyJTQ0ZfQVBJX0tFWSI6InNjZl95b3VyX2FwaV9rZXlfaGVyZSIsIlNDRl9BUElfVVJMIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwIn19)
+
+After install, edit the pre-filled `SCF_API_URL` to point at **your** instance — there is no hosted default.
 
 **Smithery** — managed hosted deployment:
 
@@ -110,7 +112,7 @@ For Claude Desktop ≥ 0.11.0, the easiest install is a signed `.mcpb` bundle �
 1. Download `mcp-server-scf-<version>.mcpb` from the [latest GitHub release](https://github.com/MarkAC007/mcp-server-scf/releases/latest).
 2. Double-click the file (or drag it onto Claude Desktop → **Settings → Extensions**).
 3. When prompted, paste your `scf_…` API key. It's stored in your OS keychain, not in a config file.
-4. Claude Desktop restarts the server and all 74 tools are available.
+4. Claude Desktop restarts the server and all 83 tools are available.
 
 To uninstall or update the API key later: **Settings → Extensions → SCF Controls Platform → Configure**.
 
@@ -150,8 +152,11 @@ export SCF_API_URL="http://localhost:8000"
   "mcpServers": {
     "scf": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "SCF_API_KEY", "markac007/mcp-server-scf"],
-      "env": { "SCF_API_KEY": "scf_your_api_key_here" }
+      "args": ["run", "-i", "--rm", "-e", "SCF_API_KEY", "-e", "SCF_API_URL", "markac007/mcp-server-scf"],
+      "env": {
+        "SCF_API_KEY": "scf_your_api_key_here",
+        "SCF_API_URL": "https://scf.your-domain.example"
+      }
     }
   }
 }
@@ -186,7 +191,7 @@ More examples live in each per-domain doc under [`docs/tools/`](docs/tools/).
 
 ## Documentation
 
-- [**docs/authentication.md**](docs/authentication.md) — API key setup, rotation, region selection, scopes.
+- [**docs/authentication.md**](docs/authentication.md) — API key setup, rotation, self-hosted URL configuration, scopes.
 - [**docs/architecture.md**](docs/architecture.md) — request flow, error model, rate limiting, what the server does and does not do.
 - [**docs/troubleshooting.md**](docs/troubleshooting.md) — symptom/cause/fix for the common failure modes.
 - [**docs/tools/**](docs/tools/) — per-domain reference with full parameter tables.
@@ -196,7 +201,7 @@ More examples live in each per-domain doc under [`docs/tools/`](docs/tools/).
 ## Security
 
 - API keys are never logged or included in error messages.
-- All communication uses HTTPS; keys are SHA-256 hashed server-side.
+- Keys are SHA-256 hashed server-side. Use HTTPS for any instance reachable beyond localhost.
 - Rate limiting: 100 req/min read, 20 req/min write.
 - Multi-tenant — all operations scoped to your organization.
 - npm package published with [provenance attestation](https://docs.npmjs.com/generating-provenance-statements) via OIDC trusted publishing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ MCP client (Claude Desktop / Code / Cursor)
 mcp-server-scf  (Node.js ≥18, ESM, single long-lived process)
       │  (HTTPS, Bearer token)
       ▼
-SCF Controls Platform API  (uk.scfcontrolsplatform.app by default)
+SCF Controls Platform API  (your self-hosted instance — SCF_API_URL)
 ```
 
 Because stdio is the transport, **anything written to `stdout` corrupts the protocol frame**. All logging in this server goes to `stderr` via `console.error` — including the startup banner ([`src/index.ts:44`](../src/index.ts:44)). When adding new tools, never introduce `console.log` or raw `process.stdout.write` calls.
@@ -32,12 +32,12 @@ src/
 ├── tools/
 │   ├── catalog.ts        6 tools — read-only SCF reference data
 │   ├── scoped-controls.ts 6 tools — per-org implementation tracking
-│   ├── evidence.ts       19 tools — CRUD, files, validation, AI
+│   ├── evidence.ts       21 tools — CRUD, files, validation, AI
 │   │                     assessments (per-file + windowed)
 │   ├── risk.ts           12 tools — risk register + custom risks
-│   ├── vendors.ts        7 tools — TPRM + AI research + DPSIA
+│   ├── vendors.ts        11 tools — TPRM + AI research + AI assessments
 │   ├── organization.ts   7 tools — user, orgs, audit, notifications
-│   ├── capabilities.ts   9 tools — KSI themes, systems, scorecards
+│   ├── capabilities.ts   14 tools — KSI themes, systems, catalog, recipes
 │   └── webhooks.ts       6 tools — webhook endpoints + deliveries
 └── lib/
     ├── api-client.ts     ScfApiClient — fetch wrapper with auth,
@@ -45,7 +45,7 @@ src/
     └── errors.ts         ScfApiError + formatError + errorResult.
 ```
 
-Total: **72 tools across 8 domain files**. The per-domain docs live under [`docs/tools/`](tools/).
+Total: **83 tools across 8 domain files**. The per-domain docs live under [`docs/tools/`](tools/).
 
 ---
 
@@ -67,14 +67,14 @@ The client has no retry logic — it's the caller's responsibility to retry on `
 
 All error responses use `isError: true` with a single text block. `ScfApiError` status codes are translated to user-facing messages ([`src/lib/errors.ts:12`](../src/lib/errors.ts:12)):
 
-| Status | Translated message                                                     |
-| ------ | ---------------------------------------------------------------------- |
-| 401    | "Authentication failed. Check your `SCF_API_KEY`."                     |
-| 402    | "Subscription limit reached. Upgrade your plan to continue."           |
-| 403    | "Access denied. Your API key may lack permissions for this operation." |
-| 404    | `Not found: ${error.message}`                                          |
-| 429    | "Rate limited. Please wait before retrying."                           |
-| Other  | `API error (${statusCode}): ${error.message}`                          |
+| Status | Translated message                                                           |
+| ------ | ---------------------------------------------------------------------------- |
+| 401    | "Authentication failed. Check your `SCF_API_KEY`."                           |
+| 402    | "Usage limit reached on your instance. Check its plan/limits configuration." |
+| 403    | "Access denied. Your API key may lack permissions for this operation."       |
+| 404    | `Not found: ${error.message}`                                                |
+| 429    | "Rate limited. Please wait before retrying."                                 |
+| Other  | `API error (${statusCode}): ${error.message}`                                |
 
 Non-`ScfApiError` errors (network failures, JSON parse errors) fall through to `error.message`. API keys are never logged and never included in the error payload.
 
@@ -88,12 +88,12 @@ The platform enforces **100 read requests/min and 20 write requests/min** per AP
 
 ## Configuration
 
-Configuration is environment-only — there is no config file. See [`docs/authentication.md`](authentication.md) for API key setup and region selection.
+Configuration is environment-only — there is no config file. See [`docs/authentication.md`](authentication.md) for API key setup.
 
-| Variable      | Required | Default                              | Purpose                                                  |
-| ------------- | -------- | ------------------------------------ | -------------------------------------------------------- |
-| `SCF_API_KEY` | Yes      | —                                    | Bearer token for every request (format: `scf_…`)         |
-| `SCF_API_URL` | No       | `https://uk.scfcontrolsplatform.app` | Platform endpoint; switch to the US endpoint if required |
+| Variable      | Required | Default | Purpose                                                                                 |
+| ------------- | -------- | ------- | --------------------------------------------------------------------------------------- |
+| `SCF_API_KEY` | Yes      | —       | Bearer token for every request (format: `scf_…`)                                        |
+| `SCF_API_URL` | Yes      | —       | Base URL of your self-hosted instance (e.g. `http://localhost:8000`); no hosted default |
 
 ---
 

--- a/docs/assets/banner.svg
+++ b/docs/assets/banner.svg
@@ -52,7 +52,7 @@
 
   <!-- Stats -->
   <text x="440" y="475" font-family="Helvetica Neue, Helvetica, Arial, sans-serif"
-        font-size="19" fill="#90A4AE">72 tools  ·  1,451 controls  ·  354+ frameworks</text>
+        font-size="19" fill="#90A4AE">83 tools  ·  1,451 controls  ·  354+ frameworks</text>
 
   <!-- Maintained by -->
   <text x="440" y="555" font-family="Helvetica Neue, Helvetica, Arial, sans-serif"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -6,7 +6,9 @@
 
 ## Getting an API key
 
-1. Sign up or sign in at [uk.scfcontrolsplatform.app](https://uk.scfcontrolsplatform.app) (UK data residency).
+The SCF Controls Platform is **self-hosted** — there is no hosted/SaaS instance. Keys are generated in your own deployment ([deploy one from the OSS repo](https://github.com/MarkAC007/scf-controls-platform-oss)):
+
+1. Sign in to **your own instance** (e.g. `http://localhost:8000`).
 2. Open **Settings → API Keys**.
 3. Click **Generate New Key**.
 4. Copy the key immediately — it's shown once. Keys are stored server-side as SHA-256 hashes and cannot be recovered after the dialog closes.
@@ -37,7 +39,7 @@ The server reads the environment only when the first tool is called ([`src/lib/a
       "args": ["-y", "mcp-server-scf"],
       "env": {
         "SCF_API_KEY": "scf_your_api_key_here",
-        "SCF_API_URL": "https://uk.scfcontrolsplatform.app"
+        "SCF_API_URL": "https://scf.your-domain.example"
       }
     }
   }
@@ -54,7 +56,7 @@ Config paths:
 ```bash
 claude mcp add scf -- npx -y mcp-server-scf
 export SCF_API_KEY="scf_your_api_key_here"
-export SCF_API_URL="https://uk.scfcontrolsplatform.app"
+export SCF_API_URL="https://scf.your-domain.example"
 ```
 
 Claude Code inherits your shell environment, so `export` in your shell profile works here. Claude Desktop does not.
@@ -69,7 +71,7 @@ Claude Code inherits your shell environment, so `export` in your shell profile w
       "args": ["-y", "mcp-server-scf"],
       "env": {
         "SCF_API_KEY": "scf_your_api_key_here",
-        "SCF_API_URL": "https://uk.scfcontrolsplatform.app"
+        "SCF_API_URL": "https://scf.your-domain.example"
       }
     }
   }
@@ -85,9 +87,10 @@ Both clients use an `mcp.json` (or equivalent) in the workspace or user config d
   "mcpServers": {
     "scf": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "SCF_API_KEY", "markac007/mcp-server-scf"],
+      "args": ["run", "-i", "--rm", "-e", "SCF_API_KEY", "-e", "SCF_API_URL", "markac007/mcp-server-scf"],
       "env": {
-        "SCF_API_KEY": "scf_your_api_key_here"
+        "SCF_API_KEY": "scf_your_api_key_here",
+        "SCF_API_URL": "https://scf.your-domain.example"
       }
     }
   }
@@ -100,7 +103,7 @@ The `-e SCF_API_KEY` flag (without a value) passes the variable through from the
 
 ## Platform URL
 
-The platform runs in the UK (`https://uk.scfcontrolsplatform.app`) — this is the default and currently the only region. `SCF_API_URL` exists so future regions can be selected without a code change; for now, leave it unset or set it to the UK URL explicitly.
+There is no default URL. The former hosted instance (`uk.scfcontrolsplatform.app`) has been **decommissioned** — the platform is self-hosted only, so `SCF_API_URL` is **required** and must point at the base URL of your own deployment (e.g. `http://localhost:8000` for a local Docker Compose stack, or wherever you expose it). The server refuses to start a request without it and tells you exactly this.
 
 ---
 
@@ -126,6 +129,6 @@ Today there is one key type with full access to any organization the user belong
 
 - **Never logged.** `SCF_API_KEY` is never printed to stderr, never included in error messages, never appears in `--debug` output.
 - **Server-side hashing.** Keys are stored as SHA-256 hashes; the platform operator cannot retrieve your plaintext key.
-- **HTTPS only.** The platform rejects plain HTTP. The client does not support custom CAs.
+- **Use HTTPS across networks.** Plain HTTP is acceptable only for localhost/loopback deployments; anything reachable over a network should sit behind TLS (reverse proxy). The client does not support custom CAs.
 - **Short-lived mutations.** Pre-signed download URLs returned by `scf_get_evidence_file` expire after 15 minutes.
 - **npm provenance.** Every published version is cryptographically linked to its source commit via [npm provenance attestations](https://docs.npmjs.com/generating-provenance-statements) issued through GitHub Actions OIDC — no long-lived npm tokens anywhere in the release pipeline.

--- a/docs/tools/capabilities.md
+++ b/docs/tools/capabilities.md
@@ -73,27 +73,30 @@ List an organization's capabilities. Capabilities map to systems and evidence, s
 
 ## `scf_list_systems`
 
-List the organization's infrastructure systems — the tools and platforms that implement security capabilities.
+List the organization's infrastructure systems — the tools and platforms that implement security capabilities. Optionally filter by linked vendor.
 
-| Parameter | Type   | Required | Description            |
-| --------- | ------ | -------- | ---------------------- |
-| `org_id`  | string | Yes      | Organization ID (UUID) |
+| Parameter   | Type   | Required | Description                                            |
+| ----------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`    | string | Yes      | Organization ID (UUID)                                 |
+| `vendor_id` | string | No       | Only systems structurally linked to this vendor (UUID) |
 
 ---
 
 ## `scf_create_system`
 
-Create a system in the organization's infrastructure inventory (write — editor+ role). Systems can be linked to capabilities and evidence.
+Create a system in the organization's infrastructure inventory (write — editor+ role). Systems can be linked to capabilities, evidence, a vendor, and a catalog template.
 
-| Parameter     | Type   | Required | Description                                                                                                                        |
-| ------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `org_id`      | string | Yes      | Organization ID (UUID)                                                                                                             |
-| `name`        | string | Yes      | System name                                                                                                                        |
-| `system_type` | string | Yes      | `cloud_provider`, `identity_provider`, `ticketing`, `logging`, `security_tool`, `code_repository`, `document_management`, `custom` |
-| `description` | string | No       | System description                                                                                                                 |
-| `status`      | string | No       | `active` (default), `inactive`, `deprecated`                                                                                       |
-| `vendor`      | string | No       | Vendor ID — get from `scf_list_vendors`                                                                                            |
-| `category`    | string | No       | System category (e.g., `SIEM`, `Endpoint`, `Identity`)                                                                             |
+| Parameter             | Type   | Required | Description                                                                                                                        |
+| --------------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `org_id`              | string | Yes      | Organization ID (UUID)                                                                                                             |
+| `name`                | string | Yes      | System name                                                                                                                        |
+| `system_type`         | string | Yes      | `cloud_provider`, `identity_provider`, `ticketing`, `logging`, `security_tool`, `code_repository`, `document_management`, `custom` |
+| `description`         | string | No       | System description                                                                                                                 |
+| `status`              | string | No       | `active` (default), `inactive`, `deprecated`                                                                                       |
+| `vendor`              | string | No       | Legacy free-text vendor name (prefer `vendor_id`)                                                                                  |
+| `vendor_id`           | string | No       | Vendor UUID for a structural link (same org) — get from `scf_list_vendors`                                                         |
+| `catalog_template_id` | number | No       | System-catalog template ID — get from `scf_list_system_catalog`                                                                    |
+| `category`            | string | No       | System category (e.g., `SIEM`, `Endpoint`, `Identity`)                                                                             |
 
 ---
 
@@ -101,16 +104,71 @@ Create a system in the organization's infrastructure inventory (write — editor
 
 Update an existing system record (write — editor+ role). All fields are optional; only provided fields are applied.
 
-| Parameter     | Type   | Required | Description                             |
-| ------------- | ------ | -------- | --------------------------------------- |
-| `org_id`      | string | Yes      | Organization ID (UUID)                  |
-| `system_id`   | string | Yes      | System ID — get from `scf_list_systems` |
-| `name`        | string | No       | System name                             |
-| `description` | string | No       | System description                      |
-| `system_type` | string | No       | Same enum as `scf_create_system`        |
-| `status`      | string | No       | `active`, `inactive`, `deprecated`      |
-| `vendor`      | string | No       | Vendor ID                               |
-| `category`    | string | No       | System category                         |
+| Parameter             | Type   | Required | Description                                       |
+| --------------------- | ------ | -------- | ------------------------------------------------- |
+| `org_id`              | string | Yes      | Organization ID (UUID)                            |
+| `system_id`           | string | Yes      | System ID — get from `scf_list_systems`           |
+| `name`                | string | No       | System name                                       |
+| `description`         | string | No       | System description                                |
+| `system_type`         | string | No       | Same enum as `scf_create_system`                  |
+| `status`              | string | No       | `active`, `inactive`, `deprecated`                |
+| `vendor`              | string | No       | Legacy free-text vendor name (prefer `vendor_id`) |
+| `vendor_id`           | string | No       | Vendor UUID for a structural link (same org)      |
+| `catalog_template_id` | number | No       | System-catalog template ID                        |
+| `category`            | string | No       | System category                                   |
+
+---
+
+## `scf_list_system_catalog`
+
+List system-catalog templates — the platform's knowledge base of known vendors/tools with slug, vendor, type, and available recipe maturity levels. Not org-scoped.
+
+| Parameter | Type   | Required | Description                                         |
+| --------- | ------ | -------- | --------------------------------------------------- |
+| `search`  | string | No       | Free-text search across names, vendors, and aliases |
+
+---
+
+## `scf_get_system_catalog_template`
+
+Get one system-catalog template by slug with full detail: aliases and curated evidence-collection recipes (maturity level, steps, frequency, estimated time).
+
+| Parameter | Type   | Required | Description                                    |
+| --------- | ------ | -------- | ---------------------------------------------- |
+| `slug`    | string | Yes      | Template slug — from `scf_list_system_catalog` |
+
+---
+
+## `scf_get_system_recipes`
+
+Get evidence-collection recipes for a system, matched via its catalog template, alias, or fallback. Returns `matched_via` (`template`/`alias`/`fallback`/`none`), the template summary, and per-maturity-level recipes.
+
+| Parameter   | Type   | Required | Description                             |
+| ----------- | ------ | -------- | --------------------------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID)                  |
+| `system_id` | string | Yes      | System ID — get from `scf_list_systems` |
+
+---
+
+## `scf_generate_system_recipes`
+
+Queue AI generation of evidence-collection recipes for a system (write — editor+ role, async, HTTP 202). Poll `scf_get_recipe_generation_status`.
+
+| Parameter   | Type   | Required | Description                             |
+| ----------- | ------ | -------- | --------------------------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID)                  |
+| `system_id` | string | Yes      | System ID — get from `scf_list_systems` |
+
+---
+
+## `scf_get_recipe_generation_status`
+
+Get the status of a queued AI recipe-generation job for a system.
+
+| Parameter   | Type   | Required | Description                             |
+| ----------- | ------ | -------- | --------------------------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID)                  |
+| `system_id` | string | Yes      | System ID — get from `scf_list_systems` |
 
 ---
 
@@ -119,4 +177,6 @@ Update an existing system record (write — editor+ role). All fields are option
 - "Give me the KSI scorecard for my org."
 - "What's our evidence posture on `ACCESS_CONTROL`?"
 - "List all systems in our infrastructure inventory."
-- "Add Okta as an identity provider."
+- "Add Okta as an identity provider and link it to the Okta vendor record."
+- "Is GitHub in the system catalog? Show me its evidence recipes."
+- "Generate evidence-collection recipes for our SIEM system."

--- a/docs/tools/evidence.md
+++ b/docs/tools/evidence.md
@@ -39,6 +39,7 @@ Create an evidence tracking record from a catalog evidence ID (write — editor+
 | `collecting_system`    | string  | No       | System or tool used to collect the evidence                                   |
 | `owner`                | string  | No       | Person responsible for this evidence item                                     |
 | `frequency`            | string  | No       | `daily`, `weekly`, `monthly`, `quarterly`, `annually`                         |
+| `maturity_level`       | string  | No       | Evidence maturity level `L0`–`L5` (e.g., `L3`)                                |
 | `comments`             | string  | No       | Additional notes or context                                                   |
 
 ---
@@ -47,17 +48,18 @@ Create an evidence tracking record from a catalog evidence ID (write — editor+
 
 Upsert an evidence item's tracking fields (write — editor+ role). Creates the tracking row if missing. All body fields are optional; only provided fields are applied.
 
-| Parameter              | Type    | Required | Description                                           |
-| ---------------------- | ------- | -------- | ----------------------------------------------------- |
-| `org_id`               | string  | Yes      | Organization ID (UUID)                                |
-| `evidence_id`          | string  | Yes      | Catalog evidence ID (e.g., `E-IAM-01`)                |
-| `is_tracked`           | boolean | No       | Whether this evidence item is actively tracked        |
-| `system_id`            | string  | No       | System ID (UUID) to link this evidence to             |
-| `method_of_collection` | string  | No       | `automated`, `manual`, `hybrid`                       |
-| `collecting_system`    | string  | No       | System or tool used to collect the evidence           |
-| `owner`                | string  | No       | Person responsible for this evidence item             |
-| `frequency`            | string  | No       | `daily`, `weekly`, `monthly`, `quarterly`, `annually` |
-| `comments`             | string  | No       | Additional notes or context                           |
+| Parameter              | Type    | Required | Description                                                               |
+| ---------------------- | ------- | -------- | ------------------------------------------------------------------------- |
+| `org_id`               | string  | Yes      | Organization ID (UUID)                                                    |
+| `evidence_id`          | string  | Yes      | Catalog evidence ID (e.g., `E-IAM-01`)                                    |
+| `is_tracked`           | boolean | No       | Whether this evidence item is actively tracked                            |
+| `system_id`            | string  | No       | System ID (UUID) to link this evidence to                                 |
+| `method_of_collection` | string  | No       | `automated`, `manual`, `hybrid`                                           |
+| `collecting_system`    | string  | No       | System or tool used to collect the evidence                               |
+| `owner`                | string  | No       | Person responsible for this evidence item                                 |
+| `frequency`            | string  | No       | `daily`, `weekly`, `monthly`, `quarterly`, `annually`                     |
+| `maturity_level`       | string  | No       | Evidence maturity level `L0`–`L5`; omitting never clears the stored value |
+| `comments`             | string  | No       | Additional notes or context                                               |
 
 ---
 

--- a/docs/tools/vendors.md
+++ b/docs/tools/vendors.md
@@ -1,6 +1,6 @@
 # Vendor Risk (TPRM) tools
 
-Third-party risk management with AI-powered security research (HIBP/NVD lookups, breach history, vulnerability scanning) and Data Protection Security Impact Assessments (DPSIA).
+Third-party risk management with AI-powered security research (HIBP/NVD lookups, breach history, vulnerability scanning) and async AI vendor security assessments (the platform's replacement for DPSIA).
 
 Source: [`src/tools/vendors.ts`](../../src/tools/vendors.ts).
 
@@ -89,25 +89,71 @@ Get the latest vendor research result: breach history, known vulnerabilities, an
 
 ---
 
-## `scf_trigger_dpsia`
+## `scf_trigger_vendor_assessment`
 
-Queue a Data Protection Security Impact Assessment (DPSIA) for a vendor (write — editor+ role, async). Scores posture against CIA triad and certification requirements.
+Queue an AI vendor security assessment (write — editor+ role, async, HTTP 202). Replaces the removed `scf_trigger_dpsia` tool — the platform deprecated the `/dpsia` endpoints in favour of `/assessments`. Returns `assessment_id` + `job_id`; poll `scf_get_vendor_assessment_status`.
 
-| Parameter            | Type   | Required | Description                                                           |
-| -------------------- | ------ | -------- | --------------------------------------------------------------------- |
-| `org_id`             | string | Yes      | Organization ID (UUID)                                                |
-| `vendor_id`          | string | Yes      | Vendor ID                                                             |
-| `services_used`      | string | No       | Description of services the vendor provides (auto-derived if omitted) |
-| `assessment_type`    | string | No       | `new` (default), `annual-review`, `adhoc`                             |
-| `data_role`          | string | No       | `Processor` (default), `Controller`, `Joint Controller`               |
-| `client_name`        | string | No       | Client/organisation name for the assessment                           |
-| `additional_context` | string | No       | Additional context (e.g., specific concerns, scope notes)             |
+| Parameter            | Type   | Required | Description                                                                          |
+| -------------------- | ------ | -------- | ------------------------------------------------------------------------------------ |
+| `org_id`             | string | Yes      | Organization ID (UUID)                                                               |
+| `vendor_id`          | string | Yes      | Vendor ID                                                                            |
+| `services_used`      | string | No       | Services the vendor provides, 1–2000 chars (auto-derived from the record if omitted) |
+| `assessment_type`    | string | No       | `initial` (default), `annual`, `adhoc`                                               |
+| `data_role`          | string | No       | `Processor` (default), `Controller`, `Joint Controller`                              |
+| `additional_context` | string | No       | Additional context, max 5000 chars (e.g., specific concerns, scope notes)            |
+
+---
+
+## `scf_list_vendor_assessments`
+
+List a vendor's AI security assessments, newest first. Each record includes status, RAG rating, recommendation, and report fields.
+
+| Parameter   | Type   | Required | Description            |
+| ----------- | ------ | -------- | ---------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID) |
+| `vendor_id` | string | Yes      | Vendor ID              |
+
+---
+
+## `scf_get_latest_vendor_assessment`
+
+Get a vendor's latest **completed** AI security assessment: RAG status, recommendation, executive summary, `report_markdown`/`report_json`. Returns 404 if none completed yet.
+
+| Parameter   | Type   | Required | Description            |
+| ----------- | ------ | -------- | ---------------------- |
+| `org_id`    | string | Yes      | Organization ID (UUID) |
+| `vendor_id` | string | Yes      | Vendor ID              |
+
+---
+
+## `scf_get_vendor_assessment`
+
+Get one vendor AI assessment by ID with full detail: `services_used`, `data_role`, RAG status, recommendation, full report fields, and research sources.
+
+| Parameter       | Type   | Required | Description                                         |
+| --------------- | ------ | -------- | --------------------------------------------------- |
+| `org_id`        | string | Yes      | Organization ID (UUID)                              |
+| `vendor_id`     | string | Yes      | Vendor ID                                           |
+| `assessment_id` | string | Yes      | Assessment UUID — from list or the trigger response |
+
+---
+
+## `scf_get_vendor_assessment_status`
+
+Get the job status of a queued vendor AI assessment: `status`, `started_at`, `completed_at`, `error_message`. Poll after `scf_trigger_vendor_assessment`.
+
+| Parameter       | Type   | Required | Description                                            |
+| --------------- | ------ | -------- | ------------------------------------------------------ |
+| `org_id`        | string | Yes      | Organization ID (UUID)                                 |
+| `vendor_id`     | string | Yes      | Vendor ID                                              |
+| `assessment_id` | string | Yes      | Assessment UUID — from `scf_trigger_vendor_assessment` |
 
 ---
 
 ## Example prompts
 
 - "List all critical vendors and their risk scores."
-- "Run a DPSIA on our cloud provider vendor."
+- "Run an AI security assessment on our cloud provider vendor."
 - "What breaches has our payment processor had?"
 - "Add Stripe as a critical vendor for payment processing."
+- "Show me the latest assessment report for AWS."

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,7 @@ Every tool call returns `Authentication failed. Check your SCF_API_KEY.` or the 
 One of:
 
 - The key is missing, truncated, or has a stray newline.
-- The key belongs to a different region than `SCF_API_URL` points at.
+- The key belongs to a different instance than `SCF_API_URL` points at (keys are per-deployment).
 - The key was revoked or rotated server-side.
 - The key doesn't start with `scf_` — likely a UUID copy-paste mistake.
 
@@ -24,7 +24,7 @@ One of:
    echo -n "$SCF_API_KEY" | head -c 4   # should print: scf_
    echo -n "$SCF_API_KEY" | wc -c       # should match the length shown at generation time
    ```
-2. Verify the region matches — see [Region selection](#region-selection) below.
+2. Verify `SCF_API_URL` points at the same instance that issued the key — see [Wrong `SCF_API_URL`](#wrong-scf_api_url) below.
 3. Generate a new key in **Settings → API Keys** and update every MCP client config, then restart the client.
 4. If the key works in `curl` but not in the MCP client, the client isn't passing the `env` block through — see [Claude Desktop config](#claude-desktop-config-path-per-os).
 
@@ -36,14 +36,17 @@ One of:
 Key looks correct (starts with `scf_`, length matches) but every request returns `401` or `ENOTFOUND`.
 
 **Cause**
-`SCF_API_URL` is pointing at the wrong host. The platform currently runs only at `https://uk.scfcontrolsplatform.app` — any other value will fail.
+`SCF_API_URL` is missing or pointing at the wrong host. The platform is **self-hosted** — there is no default and no hosted fallback (the former `uk.scfcontrolsplatform.app` SaaS is decommissioned; `ENOTFOUND` against it means exactly that).
 
 **Fix**
-Leave `SCF_API_URL` unset (the default already targets the UK host) or set it explicitly to:
+Set `SCF_API_URL` to the base URL of **your own instance** — the same origin you open in the browser to sign in:
 
 ```
-SCF_API_URL=https://uk.scfcontrolsplatform.app
+SCF_API_URL=http://localhost:8000          # local Docker Compose stack
+SCF_API_URL=https://scf.your-domain.example # reverse-proxied deployment
 ```
+
+If you don't have an instance yet, deploy one from [scf-controls-platform-oss](https://github.com/MarkAC007/scf-controls-platform-oss).
 
 ---
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,8 +3,8 @@
   "name": "mcp-server-scf",
   "display_name": "SCF Controls Platform",
   "version": "0.5.16",
-  "description": "MCP server for the SCF Controls Platform — 72 tools for controls, evidence, risk, and TPRM.",
-  "long_description": "Gives Claude Desktop access to 1,451 SCF security controls, 354+ framework mappings (NIST 800-53, ISO 27001, SOC 2, FedRAMP, GDPR), evidence tracking, a 5x5 risk register, and third-party vendor risk management through the SCF Controls Platform. 72 tools across 8 domains — catalog, scoping, evidence, risk, TPRM, organization, capabilities, and webhooks — all callable in natural language.",
+  "description": "MCP server for the SCF Controls Platform — 83 tools for controls, evidence, risk, and TPRM.",
+  "long_description": "Gives Claude Desktop access to 1,451 SCF security controls, 354+ framework mappings (NIST 800-53, ISO 27001, SOC 2, FedRAMP, GDPR), evidence tracking, a 5x5 risk register, and third-party vendor risk management through the SCF Controls Platform. 83 tools across 8 domains — catalog, scoping, evidence, risk, TPRM, organization, capabilities, and webhooks — all callable in natural language.",
   "author": {
     "name": "ComplianceGenie.io",
     "url": "https://compliancegenie.io"
@@ -48,16 +48,15 @@
     "api_key": {
       "type": "string",
       "title": "SCF API key",
-      "description": "Your SCF Controls Platform API key — starts with the scf_ prefix. Generate one at Settings → API Keys in the platform console.",
+      "description": "Your SCF Controls Platform API key — starts with the scf_ prefix. Generate one at Settings → API Keys in your self-hosted instance.",
       "sensitive": true,
       "required": true
     },
     "api_url": {
       "type": "string",
       "title": "Platform URL",
-      "description": "SCF Controls Platform endpoint. Defaults to https://uk.scfcontrolsplatform.app (UK data residency).",
-      "required": false,
-      "default": "https://uk.scfcontrolsplatform.app"
+      "description": "Base URL of your self-hosted SCF Controls Platform instance (e.g. http://localhost:8000). Required — the platform is self-hosted; there is no hosted default.",
+      "required": true
     }
   },
   "tools_generated": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-server-scf",
   "mcpName": "app.scfcontrolsplatform/mcp-server-scf",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "MCP server for the SCF Controls Platform — security compliance controls, frameworks, evidence, and risk management for AI agents",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "app.scfcontrolsplatform/mcp-server-scf",
-  "description": "MCP server for the SCF Controls Platform — 72 tools for controls, evidence, risk, and TPRM.",
-  "version": "1.6.3",
+  "description": "MCP server for the SCF Controls Platform — 83 tools for controls, evidence, risk, and TPRM.",
+  "version": "1.7.0",
   "repository": {
     "url": "https://github.com/MarkAC007/mcp-server-scf",
     "source": "github"
@@ -12,24 +12,23 @@
     {
       "registryType": "npm",
       "identifier": "mcp-server-scf",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "transport": {
         "type": "stdio"
       },
       "environmentVariables": [
         {
           "name": "SCF_API_KEY",
-          "description": "Your SCF Controls Platform API key. Generate at Settings > API Keys. Starts with the scf_ prefix.",
+          "description": "Your SCF Controls Platform API key. Generate in your self-hosted instance at Settings > API Keys. Starts with the scf_ prefix.",
           "isRequired": true,
           "isSecret": true,
           "format": "string"
         },
         {
           "name": "SCF_API_URL",
-          "description": "Platform API endpoint. Defaults to https://uk.scfcontrolsplatform.app (UK data residency).",
-          "isRequired": false,
-          "format": "string",
-          "default": "https://uk.scfcontrolsplatform.app"
+          "description": "Base URL of your self-hosted SCF Controls Platform instance (e.g. http://localhost:8000). Required — the platform is self-hosted; there is no hosted default.",
+          "isRequired": true,
+          "format": "string"
         }
       ]
     }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,6 +1,6 @@
 name: mcp-server-scf
 description: |
-  SCF Controls Platform MCP server — 72 tools that give AI assistants
+  SCF Controls Platform MCP server — 83 tools that give AI assistants
   access to 1,451 security controls, 354+ framework mappings
   (NIST 800-53, ISO 27001, SOC 2, FedRAMP, GDPR), evidence tracking,
   a 5x5 risk register, and third-party vendor risk management.
@@ -20,16 +20,16 @@ startCommand:
       SCF_API_URL:
         type: string
         title: Platform URL
-        default: "https://uk.scfcontrolsplatform.app"
-        description: "SCF Controls Platform API endpoint (UK data residency)."
+        description: "Base URL of your self-hosted SCF Controls Platform instance (e.g. http://localhost:8000). The platform is self-hosted — there is no hosted default."
     required:
       - SCF_API_KEY
+      - SCF_API_URL
   commandFunction: |-
     (config) => ({
       command: "node",
       args: ["build/index.js"],
       env: {
         SCF_API_KEY: config.SCF_API_KEY,
-        SCF_API_URL: config.SCF_API_URL || "https://uk.scfcontrolsplatform.app"
+        SCF_API_URL: config.SCF_API_URL
       }
     })

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -104,12 +104,23 @@ let _client: ScfApiClient | null = null;
 export function getClient(): ScfApiClient {
   if (!_client) {
     const apiKey = process.env.SCF_API_KEY;
-    const baseUrl = process.env.SCF_API_URL || "https://uk.scfcontrolsplatform.app";
+    const baseUrl = process.env.SCF_API_URL;
+
+    // The hosted SaaS (uk.scfcontrolsplatform.app) is decommissioned — the
+    // platform is self-hosted only, so there is no meaningful default URL.
+    if (!baseUrl) {
+      throw new Error(
+        "SCF_API_URL environment variable is required. " +
+          "The SCF Controls Platform is self-hosted: set SCF_API_URL to your own " +
+          "instance's base URL (e.g. http://localhost:8000). " +
+          "See https://github.com/MarkAC007/scf-controls-platform-oss to deploy one.",
+      );
+    }
 
     if (!apiKey) {
       throw new Error(
         "SCF_API_KEY environment variable is required. " +
-          "Generate one at https://uk.scfcontrolsplatform.app/settings/api-keys",
+          `Generate one in your self-hosted instance at ${baseUrl.replace(/\/+$/, "")}/settings/api-keys`,
       );
     }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -15,7 +15,7 @@ export function formatError(error: unknown): string {
     if (error.statusCode === 403) return "Access denied. Your API key may lack permissions for this operation.";
     if (error.statusCode === 404) return `Not found: ${error.message}`;
     if (error.statusCode === 429) return "Rate limited. Please wait before retrying.";
-    if (error.statusCode === 402) return "Subscription limit reached. Upgrade your plan to continue.";
+    if (error.statusCode === 402) return "Usage limit reached on your instance. Check its plan/limits configuration.";
     return `API error (${error.statusCode}): ${error.message}`;
   }
   if (error instanceof Error) return error.message;

--- a/src/tools/capabilities.ts
+++ b/src/tools/capabilities.ts
@@ -51,14 +51,19 @@ export function registerCapabilityTools(server: McpServer) {
 
   server.tool(
     "scf_list_systems",
-    "List the organization's infrastructure systems — the tools and platforms that implement security capabilities.",
+    "List the organization's infrastructure systems — the tools and platforms that implement security capabilities. Optionally filter by linked vendor.",
     {
       org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      vendor_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe("Filter to systems structurally linked to this vendor UUID — obtain from scf_list_vendors"),
     },
-    async ({ org_id }) => {
+    async ({ org_id, vendor_id }) => {
       try {
         const client = getClient();
-        const data = await client.get(`/organizations/${org_id}/systems`);
+        const data = await client.get(`/organizations/${org_id}/systems`, { vendor_id });
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       } catch (error) {
         return errorResult(error);
@@ -80,7 +85,17 @@ export function registerCapabilityTools(server: McpServer) {
         .enum(["active", "inactive", "deprecated"])
         .default("active")
         .describe("Lifecycle status (default: active)"),
-      vendor: z.string().optional().describe("Vendor UUID to link this system to — obtain from scf_list_vendors"),
+      vendor: z.string().optional().describe("Legacy free-text vendor name (prefer vendor_id for a structural link)"),
+      vendor_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe("Vendor UUID to structurally link this system to — obtain from scf_list_vendors (same org)"),
+      catalog_template_id: z
+        .number()
+        .int()
+        .optional()
+        .describe("System-catalog template ID to link — obtain from scf_list_system_catalog"),
       category: z.string().optional().describe("Free-text category (e.g., 'SIEM', 'Endpoint', 'Identity')"),
     },
     async ({ org_id, ...body }) => {
@@ -104,7 +119,17 @@ export function registerCapabilityTools(server: McpServer) {
       description: z.string().optional().describe("New system description"),
       system_type: SystemType.optional().describe("New system classification"),
       status: z.enum(["active", "inactive", "deprecated"]).optional().describe("New lifecycle status"),
-      vendor: z.string().optional().describe("New vendor UUID link"),
+      vendor: z.string().optional().describe("New legacy free-text vendor name (prefer vendor_id)"),
+      vendor_id: z
+        .string()
+        .uuid()
+        .optional()
+        .describe("New structural vendor link (UUID, same org) — obtain from scf_list_vendors"),
+      catalog_template_id: z
+        .number()
+        .int()
+        .optional()
+        .describe("New system-catalog template ID link — obtain from scf_list_system_catalog"),
       category: z.string().optional().describe("New free-text category"),
     },
     async ({ org_id, system_id, ...fields }) => {
@@ -199,6 +224,98 @@ export function registerCapabilityTools(server: McpServer) {
           limit,
           offset,
         });
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // System knowledge catalog + evidence recipes — scf-controls-platform #689
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "scf_list_system_catalog",
+    "List system-catalog templates — the platform's knowledge base of known vendors/tools (slug, vendor, type, recipe maturity levels). Optionally search by name.",
+    {
+      search: z.string().optional().describe("Free-text search across template names, vendors, and aliases"),
+    },
+    async ({ search }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/system-catalog`, { search });
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_system_catalog_template",
+    "Get one system-catalog template by slug with full detail: aliases and curated evidence-collection recipes (maturity level, steps, frequency, estimated time).",
+    {
+      slug: z.string().describe("Template slug — obtain from scf_list_system_catalog"),
+    },
+    async ({ slug }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/system-catalog/${slug}`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_system_recipes",
+    "Get evidence-collection recipes for a system, matched via its catalog template, alias, or fallback. Returns matched_via, the template summary, and per-maturity-level recipe steps.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      system_id: z.string().uuid().describe("System UUID — obtain from scf_list_systems"),
+    },
+    async ({ org_id, system_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/systems/${system_id}/recipes`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_generate_system_recipes",
+    "Queue AI generation of evidence-collection recipes for a system (write — editor+ role, async, HTTP 202). Poll scf_get_recipe_generation_status for progress.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      system_id: z.string().uuid().describe("System UUID — obtain from scf_list_systems"),
+    },
+    async ({ org_id, system_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.post(`/organizations/${org_id}/systems/${system_id}/generate-recipes`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_recipe_generation_status",
+    "Get the status of a queued AI recipe-generation job for a system. Poll this after scf_generate_system_recipes.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      system_id: z.string().uuid().describe("System UUID — obtain from scf_list_systems"),
+    },
+    async ({ org_id, system_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/systems/${system_id}/generate-recipes/status`);
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       } catch (error) {
         return errorResult(error);

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -45,6 +45,11 @@ export function registerEvidenceTools(server: McpServer) {
         .string()
         .optional()
         .describe("Collection cadence: 'daily', 'weekly', 'monthly', 'quarterly', or 'annually'"),
+      maturity_level: z
+        .string()
+        .regex(/^L[0-5]$/)
+        .optional()
+        .describe("Evidence maturity level L0–L5 (e.g., 'L3'); omit to leave unset"),
       comments: z.string().optional().describe("Free-text notes or context"),
     },
     async ({ org_id, ...body }) => {
@@ -135,6 +140,11 @@ export function registerEvidenceTools(server: McpServer) {
         .string()
         .optional()
         .describe("Collection cadence: 'daily', 'weekly', 'monthly', 'quarterly', or 'annually'"),
+      maturity_level: z
+        .string()
+        .regex(/^L[0-5]$/)
+        .optional()
+        .describe("Evidence maturity level L0–L5 (e.g., 'L3'); omitting never clears the stored value"),
       comments: z.string().optional().describe("Free-text notes or context"),
     },
     async ({ org_id, evidence_id, ...fields }) => {

--- a/src/tools/vendors.ts
+++ b/src/tools/vendors.ts
@@ -141,32 +141,35 @@ export function registerVendorTools(server: McpServer) {
   );
 
   server.tool(
-    "scf_trigger_dpsia",
-    "Queue a Data Protection Security Impact Assessment (DPSIA) for a vendor (write — editor+ role, async). Scores posture against CIA triad and certification requirements.",
+    "scf_trigger_vendor_assessment",
+    "Queue an AI vendor security assessment (write — editor+ role, async, HTTP 202). Replaces the deprecated DPSIA trigger. Returns assessment_id + job_id; poll scf_get_vendor_assessment_status.",
     {
       org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
       vendor_id: z.string().uuid().describe("Vendor UUID — obtain from scf_list_vendors"),
       services_used: z
         .string()
+        .max(2000)
         .optional()
-        .describe("Description of services the vendor provides (auto-derived from the vendor record if omitted)"),
+        .describe(
+          "Description of services the vendor provides, 1–2000 chars (auto-derived from the vendor record if omitted)",
+        ),
       assessment_type: z
-        .enum(["new", "annual-review", "adhoc"])
+        .enum(["initial", "annual", "adhoc"])
         .optional()
-        .default("new")
-        .describe("Assessment type: 'new', 'annual-review', or 'adhoc' (default 'new')"),
+        .default("initial")
+        .describe("Assessment type: 'initial', 'annual', or 'adhoc' (default 'initial')"),
       data_role: z
         .enum(["Processor", "Controller", "Joint Controller"])
         .optional()
         .default("Processor")
         .describe("GDPR data role (default 'Processor')"),
-      client_name: z.string().optional().describe("Client or organization name appearing on the assessment"),
       additional_context: z
         .string()
+        .max(5000)
         .optional()
-        .describe("Free-text context, scope notes, or specific concerns to feed the assessor"),
+        .describe("Free-text context, scope notes, or specific concerns to feed the assessor (max 5000 chars)"),
     },
-    async ({ org_id, vendor_id, services_used, assessment_type, data_role, client_name, additional_context }) => {
+    async ({ org_id, vendor_id, services_used, assessment_type, data_role, additional_context }) => {
       try {
         const client = getClient();
 
@@ -179,13 +182,91 @@ export function registerVendorTools(server: McpServer) {
 
         const body: Record<string, string> = {
           services_used: effectiveServices,
-          assessment_type: assessment_type || "new",
+          assessment_type: assessment_type || "initial",
           data_role: data_role || "Processor",
         };
-        if (client_name) body.client_name = client_name;
         if (additional_context) body.additional_context = additional_context;
 
-        const data = await client.post(`/organizations/${org_id}/vendors/${vendor_id}/dpsia`, body);
+        const data = await client.post(`/organizations/${org_id}/vendors/${vendor_id}/assessments`, body);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_list_vendor_assessments",
+    "List a vendor's AI security assessments, newest first. Includes status, RAG rating, recommendation, and report fields per record.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      vendor_id: z.string().uuid().describe("Vendor UUID — obtain from scf_list_vendors"),
+    },
+    async ({ org_id, vendor_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/vendors/${vendor_id}/assessments`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_latest_vendor_assessment",
+    "Get a vendor's latest completed AI security assessment: RAG status, recommendation, executive summary, report_markdown/report_json. 404 if none completed yet.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      vendor_id: z.string().uuid().describe("Vendor UUID — obtain from scf_list_vendors"),
+    },
+    async ({ org_id, vendor_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/vendors/${vendor_id}/assessments/latest`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_vendor_assessment",
+    "Get one vendor AI assessment by ID with full detail: services_used, data_role, RAG status, recommendation, full report fields, and research sources.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      vendor_id: z.string().uuid().describe("Vendor UUID — obtain from scf_list_vendors"),
+      assessment_id: z
+        .string()
+        .uuid()
+        .describe("Assessment UUID — obtain from scf_list_vendor_assessments or the trigger response"),
+    },
+    async ({ org_id, vendor_id, assessment_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/vendors/${vendor_id}/assessments/${assessment_id}`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_vendor_assessment_status",
+    "Get the job status of a queued vendor AI assessment: status, started_at, completed_at, error_message. Poll this after scf_trigger_vendor_assessment.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      vendor_id: z.string().uuid().describe("Vendor UUID — obtain from scf_list_vendors"),
+      assessment_id: z.string().uuid().describe("Assessment UUID — returned by scf_trigger_vendor_assessment"),
+    },
+    async ({ org_id, vendor_id, assessment_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(
+          `/organizations/${org_id}/vendors/${vendor_id}/assessments/${assessment_id}/status`,
+        );
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       } catch (error) {
         return errorResult(error);

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -22,9 +22,9 @@ describe("formatError", () => {
     expect(msg).toMatch(/Rate limited/);
   });
 
-  it("translates 402 into a subscription-upgrade hint", () => {
+  it("translates 402 into an instance usage-limit hint", () => {
     const msg = formatError(new ScfApiError("over limit", 402));
-    expect(msg).toMatch(/Subscription limit reached/);
+    expect(msg).toMatch(/Usage limit reached/);
   });
 
   it("falls through to the generic shape for other status codes", () => {

--- a/tests/registration.test.ts
+++ b/tests/registration.test.ts
@@ -23,9 +23,9 @@ describe("tool registration", () => {
     ["scoped-controls", registerScopedControlTools, 6],
     ["evidence", registerEvidenceTools, 21],
     ["risk", registerRiskTools, 12],
-    ["vendors", registerVendorTools, 7],
+    ["vendors", registerVendorTools, 11],
     ["organization", registerOrganizationTools, 7],
-    ["capabilities", registerCapabilityTools, 9],
+    ["capabilities", registerCapabilityTools, 14],
     ["webhooks", registerWebhookTools, 6],
   ];
 
@@ -61,9 +61,9 @@ describe("tool registration", () => {
     });
   }
 
-  it("total tool count equals 74", () => {
+  it("total tool count equals 83", () => {
     const server = makeMockServer();
     for (const [, register] of cases) register(server);
-    expect(server.tool).toHaveBeenCalledTimes(74);
+    expect(server.tool).toHaveBeenCalledTimes(83);
   });
 });


### PR DESCRIPTION
## Summary

Syncs the MCP server with the platform backend API changes from merged platform PRs #683–#694, and makes the self-hosted-only deployment model explicit throughout setup.

## ⚠️ Breaking configuration change

**`SCF_API_URL` is now required.** The hosted SaaS (`uk.scfcontrolsplatform.app`) was decommissioned on 2026-06-22 — the platform is self-hosted only. There is no default base URL anymore; the server refuses to start without `SCF_API_URL` and points users at the OSS repo to deploy their own instance. Existing configs that relied on the old default will fail fast with a clear message after upgrading.

**`scf_trigger_dpsia` removed** — replaced by `scf_trigger_vendor_assessment` targeting the new `POST /organizations/{org_id}/vendors/{vendor_id}/assessments` endpoint (enum `initial|annual|adhoc`).

## API sync (74 → 83 tools)

**Vendors (7 → 11)**
- `scf_trigger_vendor_assessment` (replaces DPSIA trigger)
- `scf_list_vendor_assessments`, `scf_get_latest_vendor_assessment`, `scf_get_vendor_assessment`, `scf_get_vendor_assessment_status`

**Capabilities & Systems (9 → 14)**
- `scf_list_system_catalog`, `scf_get_system_catalog_template`
- `scf_get_system_recipes`, `scf_generate_system_recipes`, `scf_get_recipe_generation_status`
- `vendor_id` (structural link) + `catalog_template_id` on create/update system; `vendor_id` filter on `scf_list_systems`; legacy free-text `vendor` relabeled

**Evidence**
- `maturity_level` (`L0`–`L5`) on `scf_create_evidence` / `scf_update_evidence`

**Other**
- 402 error message no longer implies a hosted subscription plan
- README/docs/server.json/mcpb manifest/smithery.yaml updated for self-hosted setup; Cursor deeplink re-encoded with `SCF_API_URL` placeholder; version 1.7.0

## Verification

- `npm run build` — zero errors
- `npm test` — 37/37 pass (registration counts updated: vendors 11, capabilities 14, total 83)
- `npm run lint` — 0 errors (2 pre-existing `no-explicit-any` warnings)
- `npm run format:check` — clean
- Boot test: server starts on stdio with dummy env, stdout stays empty; both missing-env error paths verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)