### PR TITLE
fix: surface 403 detail, self-heal stale org_id, add evidence guidance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Built for the **[SCF Controls Platform](https://scfcontrolsplatform.com/)**. Mai
 
 `mcp-server-scf` connects AI assistants to the [SCF Controls Platform](https://scfcontrolsplatform.com/) via MCP, enabling natural language interaction with your compliance program. Your AI can browse the full SCF control catalog, track implementation progress, manage evidence collection, assess risks, and monitor third-party vendors — all without leaving your editor or chat.
 
-**83 tools** across 8 domains — click through for full parameter tables and example prompts:
+**88 tools** across 8 domains — click through for full parameter tables and example prompts:
 
 | Domain                                           | Tools | Description                                                                                                      |
 | ------------------------------------------------ | ----- | ---------------------------------------------------------------------------------------------------------------- |
 | [Catalog](docs/tools/catalog.md)                 | 6     | Browse 1,451 controls, 354+ frameworks, 5,736 assessment objectives                                              |
 | [Control Scoping](docs/tools/scoped-controls.md) | 6     | Track implementation status across an 8-state workflow                                                           |
-| [Evidence](docs/tools/evidence.md)               | 21    | Manage evidence collection, validation, maturity scoring, windowed AI assessments, and control-composite rollups |
+| [Evidence](docs/tools/evidence.md)               | 26    | Manage evidence collection, validation, maturity scoring, windowed AI assessments, and control-composite rollups |
 | [Risk Management](docs/tools/risk.md)            | 12    | 5x5 risk matrix, risk register, custom risks and control mapping                                                 |
 | [Vendor Risk (TPRM)](docs/tools/vendors.md)      | 11    | Vendor registry, AI security research, async AI assessments (replaces DPSIA)                                     |
 | [Organization](docs/tools/organization.md)       | 7     | Users, orgs, audit trail, work queue, notifications                                                              |
@@ -70,7 +70,7 @@ Kick the tires without adding the server to a client — [MCP Inspector](https:/
 npx @modelcontextprotocol/inspector npx -y mcp-server-scf
 ```
 
-Inspector opens on `http://localhost:6274` and connects to `mcp-server-scf` over stdio. You'll see all 83 tools, grouped by domain, with their Zod schemas rendered as a live form.
+Inspector opens on `http://localhost:6274` and connects to `mcp-server-scf` over stdio. You'll see all 88 tools, grouped by domain, with their Zod schemas rendered as a live form.
 
 Live tool calls need your instance's URL and an API key — export `SCF_API_URL` and `SCF_API_KEY` in the same shell before launching Inspector, or set them under the "Environment Variables" tab inside the Inspector UI. Without them, you can still browse schemas and descriptions; tool calls return a configuration error.
 
@@ -112,7 +112,7 @@ For Claude Desktop ≥ 0.11.0, the easiest install is a signed `.mcpb` bundle �
 1. Download `mcp-server-scf-<version>.mcpb` from the [latest GitHub release](https://github.com/MarkAC007/mcp-server-scf/releases/latest).
 2. Double-click the file (or drag it onto Claude Desktop → **Settings → Extensions**).
 3. When prompted, paste your `scf_…` API key. It's stored in your OS keychain, not in a config file.
-4. Claude Desktop restarts the server and all 83 tools are available.
+4. Claude Desktop restarts the server and all 88 tools are available.
 
 To uninstall or update the API key later: **Settings → Extensions → SCF Controls Platform → Configure**.
 

--- a/docs/tools/evidence.md
+++ b/docs/tools/evidence.md
@@ -4,13 +4,67 @@ Track evidence artifacts that demonstrate control implementation, run AI-powered
 
 Source: [`src/tools/evidence.ts`](../../src/tools/evidence.ts).
 
-The 19 tools in this domain split into five concerns:
+The 26 tools in this domain split into six concerns:
 
 1. **CRUD** — `scf_list_evidence`, `scf_create_evidence`, `scf_update_evidence`, `scf_get_evidence_maturity`, `scf_list_evidence_tasks`
 2. **Files** — `scf_list_evidence_files`, `scf_get_evidence_file`
 3. **Validation** — `scf_get_evidence_validation`, `scf_revalidate_evidence_file`, `scf_get_evidence_validation_summary`
 4. **Per-file AI assessment** — `scf_trigger_evidence_assessment`, `scf_get_evidence_assessment`, `scf_bulk_assess_evidence`, `scf_get_evidence_assessment_summary`
 5. **Windowed AI assessment** — `scf_trigger_window_assessment`, `scf_list_window_assessments`, `scf_get_window_assessment`, `scf_bulk_assess_windows`, `scf_get_window_assessment_summary`
+6. **Maturity guidance** — `scf_get_evidence_item_maturity`, `scf_get_evidence_upgrade_recommendations`, `scf_get_evidence_suggestions`, `scf_list_evidence_gaps`, `scf_get_evidence_health`
+
+---
+
+## `scf_get_evidence_item_maturity`
+
+Get one evidence item's collection maturity: current level (1=Ad Hoc to 5=Optimized), contributing factors, upgrade potential, and tracking state.
+
+| Parameter     | Type   | Required | Description                                                   |
+| ------------- | ------ | -------- | ------------------------------------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID) — get from `scf_list_organizations`    |
+| `evidence_id` | string | Yes      | Evidence ID (e.g., `E-RSK-02`) — get from `scf_list_evidence` |
+
+---
+
+## `scf_get_evidence_upgrade_recommendations`
+
+Get upgrade-path recommendations for maturing one evidence item's collection: target level, effort, impact, and step-by-step actions — the same guidance shown in the platform UI.
+
+| Parameter     | Type   | Required | Description                                                   |
+| ------------- | ------ | -------- | ------------------------------------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID) — get from `scf_list_organizations`    |
+| `evidence_id` | string | Yes      | Evidence ID (e.g., `E-RSK-02`) — get from `scf_list_evidence` |
+
+---
+
+## `scf_get_evidence_suggestions`
+
+Get system-aware collection suggestions for one evidence item: which tracked system currently collects it, which in-scope systems are capable of collecting it, and tailored collection guidance.
+
+| Parameter     | Type   | Required | Description                                                   |
+| ------------- | ------ | -------- | ------------------------------------------------------------- |
+| `org_id`      | string | Yes      | Organization ID (UUID) — get from `scf_list_organizations`    |
+| `evidence_id` | string | Yes      | Evidence ID (e.g., `E-RSK-02`) — get from `scf_list_evidence` |
+
+---
+
+## `scf_list_evidence_gaps`
+
+List the organization's evidence coverage gaps: evidence required by in-scope controls that is not yet tracked, with overall coverage percentage.
+
+| Parameter | Type   | Required | Description                                                |
+| --------- | ------ | -------- | ---------------------------------------------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) — get from `scf_list_organizations` |
+
+---
+
+## `scf_get_evidence_health`
+
+Get evidence collection health for the organization: per-item freshness status (green/amber/red) against collection frequency, with a roll-up summary.
+
+| Parameter | Type   | Required | Description                                                |
+| --------- | ------ | -------- | ---------------------------------------------------------- |
+| `org_id`  | string | Yes      | Organization ID (UUID) — get from `scf_list_organizations` |
 
 ---
 

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -13,13 +13,35 @@ export interface PaginatedResponse<T> {
   pages: number;
 }
 
+const ORG_PATH_PATTERN = /^(\/organizations\/)([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/|$)/i;
+
 export class ScfApiClient {
   private baseUrl: string;
   private apiKey: string;
+  private soleOrgId: string | null = null;
 
   constructor(config: ApiClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/+$/, "");
     this.apiKey = config.apiKey;
+  }
+
+  /**
+   * Resolve the single organization this API key can access, if exactly one.
+   * Used to self-heal org-scoped calls that arrive with a wrong/stale org_id
+   * (e.g. a UUID remembered from before an instance re-provision).
+   */
+  private async resolveSoleOrgId(): Promise<string | null> {
+    if (this.soleOrgId) return this.soleOrgId;
+    try {
+      const orgs = await this.request<Array<{ id: string }>>("GET", "/organizations", undefined, true);
+      if (Array.isArray(orgs) && orgs.length === 1 && typeof orgs[0]?.id === "string") {
+        this.soleOrgId = orgs[0].id;
+        return this.soleOrgId;
+      }
+    } catch {
+      // Resolution is best-effort; the original 403 will surface instead.
+    }
+    return null;
   }
 
   private async request<T>(
@@ -29,6 +51,7 @@ export class ScfApiClient {
       params?: Record<string, string | number | boolean | undefined>;
       body?: unknown;
     },
+    noOrgRetry = false,
   ): Promise<T> {
     const url = new URL(`${this.baseUrl}/api${path}`);
 
@@ -72,6 +95,24 @@ export class ScfApiClient {
       } catch {
         // Use status text as fallback
       }
+
+      // Self-heal a stale/wrong org_id: when an org-scoped call is denied but
+      // the key can access exactly one organization, retry once against it.
+      // This never broadens access — the retry target is proven accessible.
+      if (response.status === 403 && !noOrgRetry) {
+        const match = path.match(ORG_PATH_PATTERN);
+        if (match) {
+          const soleOrg = await this.resolveSoleOrgId();
+          if (soleOrg && soleOrg.toLowerCase() !== match[2].toLowerCase()) {
+            console.error(
+              `[mcp-server-scf] org_id ${match[2]} was denied; retrying with the key's sole accessible org ${soleOrg}`,
+            );
+            const healedPath = path.replace(ORG_PATH_PATTERN, `$1${soleOrg}$3`);
+            return this.request<T>(method, healedPath, options, true);
+          }
+        }
+      }
+
       throw new ScfApiError(detail, response.status);
     }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -12,7 +12,12 @@ export class ScfApiError extends Error {
 export function formatError(error: unknown): string {
   if (error instanceof ScfApiError) {
     if (error.statusCode === 401) return "Authentication failed. Check your SCF_API_KEY.";
-    if (error.statusCode === 403) return "Access denied. Your API key may lack permissions for this operation.";
+    if (error.statusCode === 403)
+      return (
+        `Access denied by the platform: ${error.message}. ` +
+        "If this is an organization-scoped call, the org_id may be wrong or stale — " +
+        "call scf_list_organizations to see which organization(s) this API key can access, then retry with that org_id."
+      );
     if (error.statusCode === 404) return `Not found: ${error.message}`;
     if (error.statusCode === 429) return "Rate limited. Please wait before retrying.";
     if (error.statusCode === 402) return "Usage limit reached on your instance. Check its plan/limits configuration.";

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -82,7 +82,7 @@ export function registerEvidenceTools(server: McpServer) {
 
   server.tool(
     "scf_get_evidence_item_maturity",
-    "Get one evidence item's collection maturity: current level (1=Ad Hoc to 5=Optimized), level description, contributing factors, upgrade potential, and tracking state. Use this to answer 'where does this evidence item sit today?'",
+    "Get one evidence item's collection maturity: current level (1=Ad Hoc to 5=Optimized), contributing factors, upgrade potential, and tracking state.",
     {
       org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
       evidence_id: z.string().describe("Evidence ID (e.g., 'E-RSK-02') — obtain from scf_list_evidence"),
@@ -100,7 +100,7 @@ export function registerEvidenceTools(server: McpServer) {
 
   server.tool(
     "scf_get_evidence_upgrade_recommendations",
-    "Get concrete recommendations for maturing one evidence item's collection: target level, effort, impact, and step-by-step actions (the same upgrade-path guidance shown in the platform UI). Use this to answer 'what is our next step in maturing evidence collection for X?'",
+    "Get upgrade-path recommendations for maturing one evidence item's collection: target level, effort, impact, and step-by-step actions — the same guidance shown in the platform UI.",
     {
       org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
       evidence_id: z.string().describe("Evidence ID (e.g., 'E-RSK-02') — obtain from scf_list_evidence"),

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -81,6 +81,94 @@ export function registerEvidenceTools(server: McpServer) {
   );
 
   server.tool(
+    "scf_get_evidence_item_maturity",
+    "Get one evidence item's collection maturity: current level (1=Ad Hoc to 5=Optimized), level description, contributing factors, upgrade potential, and tracking state. Use this to answer 'where does this evidence item sit today?'",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      evidence_id: z.string().describe("Evidence ID (e.g., 'E-RSK-02') — obtain from scf_list_evidence"),
+    },
+    async ({ org_id, evidence_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/evidence/${evidence_id}/maturity`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_evidence_upgrade_recommendations",
+    "Get concrete recommendations for maturing one evidence item's collection: target level, effort, impact, and step-by-step actions (the same upgrade-path guidance shown in the platform UI). Use this to answer 'what is our next step in maturing evidence collection for X?'",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      evidence_id: z.string().describe("Evidence ID (e.g., 'E-RSK-02') — obtain from scf_list_evidence"),
+    },
+    async ({ org_id, evidence_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/evidence/${evidence_id}/upgrade-recommendations`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_evidence_suggestions",
+    "Get system-aware collection suggestions for one evidence item: which tracked system currently collects it, which in-scope systems are capable of collecting it, and tailored collection guidance.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+      evidence_id: z.string().describe("Evidence ID (e.g., 'E-RSK-02') — obtain from scf_list_evidence"),
+    },
+    async ({ org_id, evidence_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/evidence/${evidence_id}/suggestions`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_list_evidence_gaps",
+    "List the organization's evidence coverage gaps: evidence required by in-scope controls that is not yet tracked, with overall coverage percentage.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+    },
+    async ({ org_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/evidence-gaps`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "scf_get_evidence_health",
+    "Get evidence collection health for the organization: per-item freshness status (green/amber/red) against collection frequency, with a roll-up summary.",
+    {
+      org_id: z.string().uuid().describe("Organization UUID — obtain from scf_list_organizations"),
+    },
+    async ({ org_id }) => {
+      try {
+        const client = getClient();
+        const data = await client.get(`/organizations/${org_id}/evidence-health`);
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.tool(
     "scf_list_evidence_files",
     "List all files uploaded or ingested for an evidence item. Returns filename, content type, upload timestamp, validation status, and a pre-signed download URL (15-min expiry).",
     {

--- a/tests/registration.test.ts
+++ b/tests/registration.test.ts
@@ -21,7 +21,7 @@ describe("tool registration", () => {
   const cases: Array<[string, (s: McpServer) => void, number]> = [
     ["catalog", registerCatalogTools, 6],
     ["scoped-controls", registerScopedControlTools, 6],
-    ["evidence", registerEvidenceTools, 21],
+    ["evidence", registerEvidenceTools, 26],
     ["risk", registerRiskTools, 12],
     ["vendors", registerVendorTools, 11],
     ["organization", registerOrganizationTools, 7],
@@ -61,9 +61,9 @@ describe("tool registration", () => {
     });
   }
 
-  it("total tool count equals 83", () => {
+  it("total tool count equals 88", () => {
     const server = makeMockServer();
     for (const [, register] of cases) register(server);
-    expect(server.tool).toHaveBeenCalledTimes(83);
+    expect(server.tool).toHaveBeenCalledTimes(88);
   });
 });


### PR DESCRIPTION
## Problem

When an org-scoped tool call carries a wrong or stale `org_id` (e.g. a UUID remembered from before an instance re-provision), the server returned a generic "Access denied" for every org-scoped tool. The platform's actual 403 detail was discarded, so the calling model had no way to diagnose or self-correct — sessions degraded to catalog-only answers even though the platform held rich org data.

Separately, five platform guidance endpoints (per-item evidence maturity, upgrade recommendations, collection suggestions, evidence gaps, evidence health) had no MCP tool coverage, so the upgrade-path guidance visible in the UI was unreachable via MCP.

## Changes

- **errors.ts** — 403 responses now pass the platform's detail message through, plus a recovery hint to call `scf_list_organizations` and retry with a valid `org_id`.
- **api-client.ts** — one-shot self-heal: when an org-scoped call is denied with 403 and the API key can access exactly **one** organization (verified live via `GET /organizations`), retry once against that org. Multi-org keys are never rerouted and non-org paths are never retried, so access is never broadened.
- **tools/evidence.ts** — five new read-only tools: `scf_get_evidence_item_maturity`, `scf_get_evidence_upgrade_recommendations`, `scf_get_evidence_suggestions`, `scf_list_evidence_gaps`, `scf_get_evidence_health`.

## Verification

- `npm run build` (tsc) clean
- Stubbed-fetch unit suite 8/8: heal works for sole-org keys; multi-org 403s surface unchanged; same-org role denials surface unchanged; non-org paths never retried; 403 text carries backend detail + hint
- All five endpoints live-probed against a self-hosted instance: 200 with real data; catalog regression clean; unauthenticated still 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)